### PR TITLE
NO-ISSUE: Add screen generator xcode template

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 excluded:
   - ${PWD}/Pods
   - ${PWD}/DerivedData
+  - Tools
 
 disabled_rules:
   - discarded_notification_center_observer

--- a/Tools/makeScreen.sh
+++ b/Tools/makeScreen.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
 name=$1
+file_module_name=$2
+
+if [ "$file_module_name" == "" ]; then
+    file_module_name=$(echo "$name")
+fi
 
 if [ "$name" != "" ]; then
     module_name=$(echo "$name")
-    mkdir -p "$module_name"
-    cd $module_name
+fi
+
+if [ "$module_name" != "" ]; then
+    mkdir -p "$file_module_name"
+    cd $file_module_name
 
 echo "import UIKit
 
@@ -33,8 +41,8 @@ protocol ${module_name}ViewState: AnyObject {
 
 // sourcery: AutoMockable
 protocol ${module_name}ModelProtocol: AnyObject {
-}" > ${module_name}Contract.swift
-echo "${module_name}Contract was created"
+}" > ${file_module_name}Contract.swift
+echo "${file_module_name}Contract was created"
 
 
 echo "import UIKit
@@ -50,8 +58,8 @@ final class ${module_name}ModuleAssembler: Assembling {
 
         return view
     }
-}" > ${module_name}Assembler.swift
-echo "${module_name}Assembler was created"
+}" > ${file_module_name}Assembler.swift
+echo "${file_module_name}Assembler was created"
 
 echo "import Foundation
 
@@ -74,8 +82,8 @@ final class ${module_name}ViewModel: ${module_name}ViewModelLifeCycle, ${module_
 
     func load() {
     }
-}" > ${module_name}ViewModel.swift
-echo "${module_name}ViewModel was created"
+}" > ${file_module_name}ViewModel.swift
+echo "${file_module_name}ViewModel was created"
 
 echo "import UIKit
 import UIComponents
@@ -104,8 +112,8 @@ final class ${module_name}ViewController: UIViewController, ${module_name}Viewab
     // MARK: - Setup
     private func setup() {
     }
-}" > ${module_name}ViewController.swift
-echo "${module_name}ViewController was created"
+}" > ${file_module_name}ViewController.swift
+echo "${file_module_name}ViewController was created"
 
 echo "import Foundation
 
@@ -114,8 +122,8 @@ final class ${module_name}Model: ${module_name}ModelProtocol {
 
     // MARK: - Initialization
     init() { }
-}" > ${module_name}Model.swift
-echo "${module_name}Model was created"
+}" > ${file_module_name}Model.swift
+echo "${file_module_name}Model was created"
     open .
 else
     echo "[ERROR] Provide screen name"

--- a/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___Assembler.swift
+++ b/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___Assembler.swift
@@ -1,0 +1,14 @@
+import UIKit
+import Common
+
+final class ___VARIABLE_productName:identifier___ModuleAssembler: Assembling {
+    static func assemble() -> UIViewController {
+        let model = ___VARIABLE_productName:identifier___Model()
+        let viewModel = ___VARIABLE_productName:identifier___ViewModel(
+            model: model
+        )
+        let view = ___VARIABLE_productName:identifier___ViewController(viewModel: viewModel)
+
+        return view
+    }
+}

--- a/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___Contract.swift
+++ b/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___Contract.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+// MARK: - View
+protocol ___VARIABLE_productName:identifier___Viewable: AnyObject {
+}
+
+// MARK: - ViewModel
+typealias ___VARIABLE_productName:identifier___ViewModelProtocol = ___VARIABLE_productName:identifier___ViewModelLifeCycle
+    & ___VARIABLE_productName:identifier___ViewInteraction
+    & ___VARIABLE_productName:identifier___ViewState
+
+protocol ___VARIABLE_productName:identifier___ViewModelLifeCycle: AnyObject {
+    func setup()
+    func load()
+}
+
+protocol ___VARIABLE_productName:identifier___ViewInteraction: AnyObject {
+}
+
+protocol ___VARIABLE_productName:identifier___ViewState: AnyObject {
+}
+
+// MARK: - Model
+
+// sourcery: AutoMockable
+protocol ___VARIABLE_productName:identifier___ModelProtocol: AnyObject {
+}

--- a/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___Model.swift
+++ b/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___Model.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+final class ___VARIABLE_productName:identifier___Model: ___VARIABLE_productName:identifier___ModelProtocol {
+    // MARK: - Private properties
+
+    // MARK: - Initialization
+    init() { }
+}

--- a/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___ViewController.swift
+++ b/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___ViewController.swift
@@ -1,0 +1,28 @@
+import UIKit
+import UIComponents
+
+final class ___VARIABLE_productName:identifier___ViewController: UIViewController, ___VARIABLE_productName:identifier___Viewable {
+    // MARK: - UI properties
+    private let viewModel: ___VARIABLE_productName:identifier___ViewModelProtocol
+
+    // MARK: - Initialization
+    init(viewModel: ___VARIABLE_productName:identifier___ViewModelProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Life cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        viewModel.load()
+    }
+
+    // MARK: - Setup
+    private func setup() {
+    }
+}

--- a/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___ViewModel.swift
+++ b/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/Screen/___FILEBASENAME___ViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class ___VARIABLE_productName:identifier___ViewModel: ___VARIABLE_productName:identifier___ViewModelLifeCycle, ___VARIABLE_productName:identifier___ViewInteraction, ___VARIABLE_productName:identifier___ViewState {
+
+    // MARK: - Dependencies
+    private let model: ___VARIABLE_productName:identifier___ModelProtocol
+
+    // MARK: - Initialization
+    init(
+        model: ___VARIABLE_productName:identifier___ModelProtocol
+    ) {
+        self.model = model
+        setup()
+    }
+
+    // MARK: - Life cycle
+    func setup() {
+    }
+
+    func load() {
+    }
+}

--- a/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/TemplateInfo.plist
+++ b/Tools/xcodeTemplates/Animeal modules/Screen.xctemplate/TemplateInfo.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SupportsSwiftPackage</key>
+	<true/>
+	<key>Kind</key>
+	<string>Xcode.IDEFoundation.TextSubstitutionFileTemplateKind</string>
+	<key>Description</key>
+	<string>An empty screen component files.</string>
+	<key>Summary</key>
+	<string>An empty screen component files</string>
+	<key>SortOrder</key>
+	<string>1</string>
+	<key>Image</key>
+	<dict>
+		<key>FileTypeIcon</key>
+		<string>swift</string>
+	</dict>
+	<key>DefaultCompletionName</key>
+	<string>ScreenComponentName_RenameMe</string>
+	<key>Options</key>
+	<array>
+		<dict>
+			<key>Identifier</key>
+			<string>productName</string>
+			<key>Required</key>
+			<true/>
+			<key>Name</key>
+			<string>Screen component name:</string>
+			<key>Description</key>
+			<string>The name of the screen component to create</string>
+			<key>Type</key>
+			<string>text</string>
+			<key>NotPersisted</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Identifier</key>
+			<string>componentType</string>
+			<key>Required</key>
+			<true/>
+			<key>Name</key>
+			<string>Type:</string>
+			<key>Description</key>
+			<string>The component type</string>
+			<key>Type</key>
+			<string>popup</string>
+			<key>Default</key>
+			<string>Screen</string>
+			<key>Values</key>
+			<array>
+				<string>Screen</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Tools/xcodeTemplates/factory/createScreenTemplate.sh
+++ b/Tools/xcodeTemplates/factory/createScreenTemplate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+screenPath="../Animeal modules/Screen.xctemplate/Screen"
+mkdir -p "$screenPath"
+cd "$screenPath"
+
+sh ../../../../makeScreen.sh ___VARIABLE_productName:identifier___ ___FILEBASENAME___
+
+mv ./___FILEBASENAME___/* ./
+rm -R ./___FILEBASENAME___

--- a/Tools/xcodeTemplates/install.sh
+++ b/Tools/xcodeTemplates/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux -o pipefail
+
+mkdir -p ~/Library/Developer/Xcode/Templates
+
+ln -s "$(pwd)/Animeal modules" ~/Library/Developer/Xcode/Templates


### PR DESCRIPTION
**Comments:**
1. Update Tools/makeScreen.sh script to split class and file names:
* script can work as before (makeScreen.sh Test -> will create all necessary files and classes with prefix Test)
* script can work by new flow (makeScreen.sh Test Test2 -> will create all necessary files with prefix Test2 and classes with prefix Test); new flow is needed to support simplified creation of template files for xcode template
2. Script Tools/xcodeTemplates/factory/createScreenTemplate.sh is used to create necessary templates for xcode template using Tools/makeScreen.sh script (already run and 'Animeal modules/Screen.xctemplate/Screen' was created, so no need to run this script only if you need to update xcode template)
3. Script Tools/xcodeTemplates/install.sh is used to install created xcode template 'Animeal modules' on local machine
4. Exclude Tools folder from .swiftlint.yml 

**How to use:**
Run script 'Tools/xcodeTemplates/install.sh' locally from folder 'xcodeTemplates' to install 'Animeal modules' into xCode:
sh ./install.sh
Note: It installs link to the folder so no need to run it again if 'Animeal modules' will be update in the further commits.

Then you can add screen module files as usual: via xcode's 'New file...' and choose Screen component of 'Animeal modules' section to create all necessary files into desired folder without using of 'Tools/makeScreen.sh'