### PR TITLE
EPMEDU-633: Add "Show on map" button for Feeding details screen

### DIFF
--- a/UIComponents/Sources/UIComponents/Components/Buttons/ButtonViewFactory.swift
+++ b/UIComponents/Sources/UIComponents/Components/Buttons/ButtonViewFactory.swift
@@ -142,4 +142,8 @@ public struct ButtonViewFactory: ButtonViewGenerating, StyleEngineContainable {
         button.backgroundColor = designEngine.colors.backgroundPrimary
         return CircleButtonView(contentView: button)
     }
+    
+    public func makeTextButton() -> ButtonView {
+        TextButtonView(contentView: UIButton(type: .system))
+    }
 }

--- a/UIComponents/Sources/UIComponents/Components/Buttons/TextButtonView.swift
+++ b/UIComponents/Sources/UIComponents/Components/Buttons/TextButtonView.swift
@@ -1,0 +1,37 @@
+import UIKit
+
+open class TextButtonView: ButtonView {
+    // MARK: - Constants
+    private enum Constants {
+        static let height: CGFloat = 44
+    }
+    
+    // MARK: - Configuration
+    public override func configure(_ model: ButtonView.Model) {
+        identifier = model.identifier
+        
+        let title = NSAttributedString(string: model.title, attributes: [
+            .foregroundColor: contentView.designEngine.colors.accent,
+            .font: contentView.designEngine.fonts.secondary.light(16) ?? .systemFont(ofSize: 16, weight: .light),
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ])
+        contentView.setAttributedTitle(title, for: .normal)
+        assert(model.icon == nil, "\(Self.self) doesn't support icon")
+    }
+    
+    // MARK: - Setup
+    public override func setup() {
+        addSubview(contentView.prepareForAutoLayout())
+        contentView.leadingAnchor ~= leadingAnchor
+        contentView.topAnchor ~= topAnchor
+        contentView.trailingAnchor ~= trailingAnchor
+        contentView.bottomAnchor ~= bottomAnchor
+        contentView.heightAnchor ~= Constants.height
+
+        contentView.addTarget(
+            self,
+            action: #selector(buttonWasPressed(_:)),
+            for: UIControl.Event.touchUpInside
+        )
+    }
+}

--- a/UIComponents/Sources/UIComponents/Extensions/UIApplication+Extensions.swift
+++ b/UIComponents/Sources/UIComponents/Extensions/UIApplication+Extensions.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+extension UIApplication {
+    var keyWindow: UIWindow? {
+        connectedScenes
+            .filter { $0.activationState == .foregroundActive }
+            .first { $0 is UIWindowScene }
+            .flatMap { $0 as? UIWindowScene }?
+            .windows
+            .first(where: \.isKeyWindow)
+    }
+}

--- a/UIComponents/Sources/UIComponents/ViewControllers/BottomSheetPresentationController/BottomSheetConfiguration.swift
+++ b/UIComponents/Sources/UIComponents/ViewControllers/BottomSheetPresentationController/BottomSheetConfiguration.swift
@@ -28,11 +28,13 @@ public struct BottomSheetConfiguration {
     }
 
     public static var fullScreen: BottomSheetConfiguration {
+        let safeAreaTopInset = UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0
+        let maxHeight = UIScreen.main.bounds.height - safeAreaTopInset
         return .init(
             maxDimmedAlpha: 0.6,
-            defaultHeight: UIScreen.main.bounds.height / 2,
-            dismissibleHeight: UIScreen.main.bounds.height / 2 - 150,
-            maximumContainerHeight: UIScreen.main.bounds.height - 50
+            defaultHeight: maxHeight,
+            dismissibleHeight: maxHeight - 150,
+            maximumContainerHeight: maxHeight
         )
     }
     

--- a/animeal/src/Flows/Auth/Modules/CustomAuth/CustomAuthViewController.swift
+++ b/animeal/src/Flows/Auth/Modules/CustomAuth/CustomAuthViewController.swift
@@ -147,9 +147,9 @@ private extension CustomAuthViewController {
         setupKeyboardHandling()
 
         view.addSubview(scrollView)
-        scrollView.leadingAnchor ~= view.leadingAnchor + 16.0
+        scrollView.leadingAnchor ~= view.leadingAnchor + 26.0
         scrollView.topAnchor ~= view.safeAreaLayoutGuide.topAnchor
-        scrollView.trailingAnchor ~= view.trailingAnchor - 16.0
+        scrollView.trailingAnchor ~= view.trailingAnchor - 26.0
         scrollView.bottomAnchor ~= view.safeAreaLayoutGuide.bottomAnchor
         scrollView.canCancelContentTouches = false
 

--- a/animeal/src/Flows/Auth/Modules/Verification/VerificationViewController.swift
+++ b/animeal/src/Flows/Auth/Modules/Verification/VerificationViewController.swift
@@ -67,9 +67,9 @@ final class VerificationViewController: BaseViewController, VerificationViewMode
         view.backgroundColor = designEngine.colors.backgroundPrimary
 
         view.addSubview(headerView)
-        headerView.leadingAnchor ~= view.safeAreaLayoutGuide.leadingAnchor + 32.0
+        headerView.leadingAnchor ~= view.safeAreaLayoutGuide.leadingAnchor + 26.0
         headerView.topAnchor ~= view.safeAreaLayoutGuide.topAnchor + 32.0
-        headerView.trailingAnchor ~= view.safeAreaLayoutGuide.trailingAnchor - 32.0
+        headerView.trailingAnchor ~= view.safeAreaLayoutGuide.trailingAnchor - 26.0
 
         view.addSubview(codeInputView)
         codeInputView.leadingAnchor ~= headerView.leadingAnchor

--- a/animeal/src/Flows/Main/Modules/Favourites/Coordinator/FavouritesCoordinator.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Coordinator/FavouritesCoordinator.swift
@@ -8,15 +8,18 @@ final class FavouritesCoordinator: Coordinatable {
     // MARK: - Dependencies
     internal var navigator: Navigating
     private let completion: ((HomeFlowBackwardEvent?) -> Void)?
+    private let switchFlowAction: ((MainFlowSwitchAction) -> Void)?
     private var backwardEvent: HomeFlowBackwardEvent?
     private var bottomSheetController: BottomSheetPresentationController?
 
     // MARK: - Initialization
     init(
         navigator: Navigator,
+        switchFlowAction: ((MainFlowSwitchAction) -> Void)? = nil,
         completion: ((HomeFlowBackwardEvent?) -> Void)? = nil
     ) {
         self.navigator = navigator
+        self.switchFlowAction = switchFlowAction
         self.completion = completion
     }
 
@@ -53,9 +56,13 @@ extension FavouritesCoordinator: FavouritesCoordinatable {
         case .details(let pointId):
             let viewController = FeedingPointDetailsModuleAssembler(
                 coordinator: self,
-                pointId: pointId
+                pointId: pointId,
+                isOverMap: false
             ).assemble()
-            let controller = BottomSheetPresentationController(controller: viewController)
+            let controller = BottomSheetPresentationController(
+                controller: viewController,
+                configuration: .fullScreen
+            )
             controller.modalPresentationStyle = .overFullScreen
             navigator.present(controller, animated: false, completion: nil)
             bottomSheetController = controller
@@ -64,6 +71,8 @@ extension FavouritesCoordinator: FavouritesCoordinatable {
 }
 
 extension FavouritesCoordinator: FeedingPointCoordinatable {
+    var isOverMap: Bool { false }
+    
     func routeTo(_ route: FeedingPointRoute) {
         switch route {
         case .feed(let feedingDetails):
@@ -74,6 +83,12 @@ extension FavouritesCoordinator: FeedingPointCoordinatable {
                 ).assemble()
                 screen.modalPresentationStyle = .overFullScreen
                 self.navigator.present(screen, animated: true, completion: nil)
+            }
+        case .map(let pointIdentifier):
+            bottomSheetController?.dismissView { [weak self] in
+                self?.switchFlowAction?(
+                    .shouldSwitchToMap(pointIdentifier: pointIdentifier)
+                )
             }
         }
     }

--- a/animeal/src/Flows/Main/Modules/Home/Coordinator/HomeCoordinator.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Coordinator/HomeCoordinator.swift
@@ -19,6 +19,7 @@ final class HomeCoordinator: Coordinatable, HomeCoordinatorEventHandlerProtocol 
     // MARK: - Home coordinator events
     var feedingDidStartedEvent: ((FeedingPointFeedDetails) -> Void)?
     var feedingDidFinishEvent: (([String]) -> Void)?
+    var moveToFeedingPointEvent: ((String) -> Void)?
 
     // MARK: - Initialization
     init(
@@ -46,7 +47,8 @@ extension HomeCoordinator: HomeCoordinatable {
         case .details(let pointId):
             let viewController = FeedingPointDetailsModuleAssembler(
                 coordinator: self,
-                pointId: pointId
+                pointId: pointId,
+                isOverMap: true
             ).assemble()
             let controller = BottomSheetPresentationController(controller: viewController)
             controller.modalPresentationStyle = .overFullScreen
@@ -77,6 +79,7 @@ extension HomeCoordinator: FeedingPointCoordinatable {
                 screen.modalPresentationStyle = .overFullScreen
                 self._navigator.present(screen, animated: true, completion: nil)
             }
+        case .map: break
         }
     }
 }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsAssembler.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsAssembler.swift
@@ -4,15 +4,18 @@ import Common
 final class FeedingPointDetailsModuleAssembler {
     private let coordinator: FeedingPointCoordinatable
     private let pointId: String
+    private let isOverMap: Bool
 
-    init(coordinator: FeedingPointCoordinatable, pointId: String) {
+    init(coordinator: FeedingPointCoordinatable, pointId: String, isOverMap: Bool) {
         self.coordinator = coordinator
         self.pointId = pointId
+        self.isOverMap = isOverMap
     }
 
     func assemble() -> UIViewController {
         let model = FeedingPointDetailsModel(pointId: pointId)
         let viewModel = FeedingPointDetailsViewModel(
+            isOverMap: isOverMap,
             model: model,
             contentMapper: FeedingPointDetailsViewMapper(),
             coordinator: coordinator

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
@@ -1,5 +1,6 @@
 import UIKit
 import CoreLocation
+import UIComponents
 
 // MARK: - View
 protocol FeedingPointDetailsViewable: AnyObject {
@@ -24,6 +25,7 @@ protocol FeedingPointDetailsViewState: AnyObject {
     var onContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointDetailsViewItem) -> Void)? { get set }
     var onMediaContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointMediaContent) -> Void)? { get set }
     var onFavoriteMutationFailed: (() -> Void)? { get set }
+    var showOnMapAction: ButtonView.Model? { get }
 }
 
 // MARK: - Model
@@ -49,6 +51,7 @@ protocol FeedingPointCoordinatable {
 // MARK: - Models
 enum FeedingPointRoute {
     case feed(FeedingPointFeedDetails)
+    case map(identifier: String)
 }
 
 struct FeedingPointFeedDetails {
@@ -59,4 +62,5 @@ struct FeedingPointFeedDetails {
 enum FeedingPointEvent {
     case tapAction
     case tapFavorite
+    case tapShowOnMap
 }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreLocation
+import UIComponents
 
 final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
                                           FeedingPointDetailsViewInteraction,
@@ -13,13 +14,26 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
     var onContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointDetailsViewItem) -> Void)?
     var onMediaContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointMediaContent) -> Void)?
     var onFavoriteMutationFailed: (() -> Void)?
+    
+    let isOverMap: Bool
+    var showOnMapAction: ButtonView.Model? {
+        if isOverMap { return .none }
+        
+        return ButtonView.Model(
+            identifier: UUID().uuidString,
+            viewType: TextButtonView.self,
+            title: L10n.Action.showOnMap
+        )
+    }
 
     // MARK: - Initialization
     init(
+        isOverMap: Bool,
         model: (FeedingPointDetailsModelProtocol & FeedingPointDetailsDataStoreProtocol),
         contentMapper: FeedingPointDetailsViewMappable,
         coordinator: FeedingPointCoordinatable
     ) {
+        self.isOverMap = isOverMap
         self.model = model
         self.contentMapper = contentMapper
         self.coordinator = coordinator
@@ -68,6 +82,10 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
                     self?.onFavoriteMutationFailed?()
                 }
             }
+        case .tapShowOnMap:
+            coordinator.routeTo(
+                .map(identifier: model.feedingPointId)
+            )
         }
     }
 }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
@@ -134,6 +134,15 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
 
         contentContainer.addArrangedSubview(UIView())
 
+        if let model = viewModel.showOnMapAction {
+            let button = ButtonViewFactory().makeTextButton()
+            button.configure(model)
+            button.onTap = { [weak self] _ in
+                self?.viewModel.handleActionEvent(.tapShowOnMap)
+            }
+            contentContainer.addArrangedSubview(button)
+        }
+        
         var button: ButtonView
         if content.action.isEnabled {
             button = ButtonViewFactory().makeAccentButton()

--- a/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
@@ -50,6 +50,7 @@ protocol HomeViewInteraction: AnyObject {
 @MainActor
 protocol HomeViewState: AnyObject {
     var onFeedingPointsHaveBeenPrepared: (([FeedingPointViewItem]) -> Void)? { get set }
+    var onFeedingPointCameraMoveRequired: ((FeedingPointCameraMove) -> Void)? { get set }
     var onSegmentsHaveBeenPrepared: ((FilterModel) -> Void)? { get set }
     var onRouteRequestHaveBeenPrepared: ((FeedingPointRouteRequest) -> Void)? { get set }
     var onFeedingActionHaveBeenPrepared: ((FeedingActionMapper.FeedingAction) -> Void)? { get set }
@@ -72,12 +73,17 @@ protocol HomeCoordinatable: AlertCoordinatable, ActivityDisplayable {
 protocol HomeCoordinatorEventHandlerProtocol {
     var feedingDidStartedEvent: ((FeedingPointFeedDetails) -> Void)? { get set }
     var feedingDidFinishEvent: (([String]) -> Void)? { get set }
+    var moveToFeedingPointEvent: ((String) -> Void)? { get set }
 }
 
 enum HomeRoute {
     case details(String)
     case attachPhoto(String)
     case feedingComplete
+}
+
+struct FeedingPointCameraMove {
+    let feedingPointCoordinate: CLLocationCoordinate2D
 }
 
 struct FeedingPointRouteRequest {

--- a/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
@@ -120,6 +120,10 @@ private extension HomeViewController {
         viewModel.onFeedingPointsHaveBeenPrepared = { [weak self] points in
             self?.applyFeedingPoints(points)
         }
+        
+        viewModel.onFeedingPointCameraMoveRequired = { [weak self] move in
+            self?.handleCameraMove(move)
+        }
 
         viewModel.onSegmentsHaveBeenPrepared = { [weak self] model in
             self?.applyFilter(model)
@@ -232,6 +236,10 @@ private extension HomeViewController {
         feedControl.stopTimer()
         mapView.cancelRouteRequest()
         hideFeedControl(true)
+    }
+    
+    func handleCameraMove(_ move: FeedingPointCameraMove) {
+        mapView.easeToLocation(move.feedingPointCoordinate, duration: 0)
     }
 }
 

--- a/animeal/src/Flows/Main/Modules/Search/Coordinator/SearchCoordinator.swift
+++ b/animeal/src/Flows/Main/Modules/Search/Coordinator/SearchCoordinator.swift
@@ -8,6 +8,7 @@ import Style
 final class SearchCoordinator: Coordinatable {
     // MARK: - Dependencies
     private let _navigator: Navigating
+    private let switchFlowAction: ((MainFlowSwitchAction) -> Void)?
     private let completion: (() -> Void)?
     private var bottomSheetController: BottomSheetPresentationController?
 
@@ -16,9 +17,11 @@ final class SearchCoordinator: Coordinatable {
     // MARK: - Initialization
     init(
         navigator: Navigator,
+        switchFlowAction: ((MainFlowSwitchAction) -> Void)?,
         completion: (() -> Void)? = nil
     ) {
         self._navigator = navigator
+        self.switchFlowAction = switchFlowAction
         self.completion = completion
     }
 
@@ -39,7 +42,8 @@ extension SearchCoordinator: SearchCoordinatable {
         case .details(let identifier):
             let viewController = FeedingPointDetailsModuleAssembler(
                 coordinator: self,
-                pointId: identifier
+                pointId: identifier,
+                isOverMap: false
             ).assemble()
             let controller = BottomSheetPresentationController(controller: viewController)
             controller.modalPresentationStyle = .overFullScreen
@@ -49,7 +53,7 @@ extension SearchCoordinator: SearchCoordinatable {
     }
 }
 
-extension SearchCoordinator: FeedingPointCoordinatable {
+extension SearchCoordinator: FeedingPointCoordinatable {    
     func routeTo(_ route: FeedingPointRoute) {
         switch route {
         case .feed(let feedingDetails):
@@ -61,6 +65,12 @@ extension SearchCoordinator: FeedingPointCoordinatable {
                 ).assemble()
                 screen.modalPresentationStyle = .overFullScreen
                 self._navigator.present(screen, animated: true, completion: nil)
+            }
+        case .map(let pointIdentifier):
+            bottomSheetController?.dismissView { [weak self] in
+                self?.switchFlowAction?(
+                    .shouldSwitchToMap(pointIdentifier: pointIdentifier)
+                )
             }
         }
     }

--- a/animeal/src/Flows/Phone/PhoneCodesViewController.swift
+++ b/animeal/src/Flows/Phone/PhoneCodesViewController.swift
@@ -8,7 +8,7 @@ final class PhoneCodesViewController: UIViewController, PhoneCodesViewable {
     // MARK: - Constants
     private enum Constants {
         static let itemHeight: CGFloat = 58.0
-        static let offset: CGFloat = 16.0
+        static let offset: CGFloat = 26.0
         static let collectionTopOffset: CGFloat = 8.0
     }
 


### PR DESCRIPTION
Added "Show on map" button for required screens
Added localizable string
Changed `BottomSheetConfiguration.fullScreen` settings to align with Figma design
Added functionality to switch flows/coordinators in `MainCoordinator`(TabBar) from child
Added functionality to move the camera on the map for specific feeding point/coordinates
Added `moveToFeedingPointEvent` to HomeCoordinator and handle it inside `HomeViewModel`