### PR TITLE
Added feeding history fetching

### DIFF
--- a/Services/Sources/Services/UserProfile/UserProfileServiceProtocol.swift
+++ b/Services/Sources/Services/UserProfile/UserProfileServiceProtocol.swift
@@ -59,6 +59,12 @@ public protocol UserProfileServiceProtocol: AnyObject {
     ///   - oldPassword: Current password of the user
     ///   - newPassword: New password to be updated
     func update(oldPassword: UserProfileInput, to newPassword: UserProfileInput) async throws
+
+    /// Fetches names for specified user list
+    ///
+    /// - Parameters:
+    ///  - userIds: List of user identifiers
+    func fetchUserNames(for userIds: [String]) async throws -> [String: String]
 }
 
 public extension UserProfileServiceProtocol {

--- a/animeal.xcodeproj/project.pbxproj
+++ b/animeal.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		8076E8A7298FBC070048B97C /* FeedingFinishedModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076E8A2298FBC070048B97C /* FeedingFinishedModel.swift */; };
 		8076E8A8298FBC070048B97C /* FeedingFinishedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076E8A3298FBC070048B97C /* FeedingFinishedViewModel.swift */; };
 		8076E8AB298FBC320048B97C /* FeedingFinishedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076E8AA298FBC320048B97C /* FeedingFinishedView.swift */; };
+		807874D229D579510005D669 /* FeederShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807874D129D579510005D669 /* FeederShimmerView.swift */; };
+		807874D429D57E790005D669 /* FeedingHistoryShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807874D329D57E790005D669 /* FeedingHistoryShimmerView.swift */; };
 		8312A5C1290AFE8F005C85CB /* PhoneCodesViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8312A5C0290AFE8F005C85CB /* PhoneCodesViewCell.swift */; };
 		8312A5C3290B0CA8005C85CB /* CustomAuthModelRequiredAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8312A5C2290B0CA8005C85CB /* CustomAuthModelRequiredAction.swift */; };
 		8312A5C5290DB689005C85CB /* PhoneModelRequiredAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8312A5C4290DB689005C85CB /* PhoneModelRequiredAction.swift */; };
@@ -428,6 +430,8 @@
 		8076E8A2298FBC070048B97C /* FeedingFinishedModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingFinishedModel.swift; sourceTree = "<group>"; };
 		8076E8A3298FBC070048B97C /* FeedingFinishedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingFinishedViewModel.swift; sourceTree = "<group>"; };
 		8076E8AA298FBC320048B97C /* FeedingFinishedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingFinishedView.swift; sourceTree = "<group>"; };
+		807874D129D579510005D669 /* FeederShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeederShimmerView.swift; sourceTree = "<group>"; };
+		807874D329D57E790005D669 /* FeedingHistoryShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingHistoryShimmerView.swift; sourceTree = "<group>"; };
 		8312A5C0290AFE8F005C85CB /* PhoneCodesViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneCodesViewCell.swift; sourceTree = "<group>"; };
 		8312A5C2290B0CA8005C85CB /* CustomAuthModelRequiredAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAuthModelRequiredAction.swift; sourceTree = "<group>"; };
 		8312A5C4290DB689005C85CB /* PhoneModelRequiredAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneModelRequiredAction.swift; sourceTree = "<group>"; };
@@ -955,6 +959,15 @@
 				8076E8AA298FBC320048B97C /* FeedingFinishedView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		807874D029D579390005D669 /* Shimmers */ = {
+			isa = PBXGroup;
+			children = (
+				807874D129D579510005D669 /* FeederShimmerView.swift */,
+				807874D329D57E790005D669 /* FeedingHistoryShimmerView.swift */,
+			);
+			path = Shimmers;
 			sourceTree = "<group>";
 		};
 		8324A2BF296B138D00AA5D32 /* Helpers */ = {
@@ -1800,6 +1813,7 @@
 		DB0E43C428D07D53007A1EB1 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				807874D029D579390005D669 /* Shimmers */,
 				DBF56B5428CF40E300AB0BDF /* FeedingPointDetailsViewController.swift */,
 				DBC5670428D879D100172FD5 /* FeedingPointDetailsViewMapper.swift */,
 			);
@@ -2690,6 +2704,7 @@
 				DBC2BB4328BBAD2B0086EF52 /* MorePartitionViewController.swift in Sources */,
 				8312A5C5290DB689005C85CB /* PhoneModelRequiredAction.swift in Sources */,
 				DB5F694628ED6CD000D8714E /* FeedingBookingViewModel.swift in Sources */,
+				807874D429D57E790005D669 /* FeedingHistoryShimmerView.swift in Sources */,
 				DBC2BB4428BBAD2B0086EF52 /* MorePartitionAssembler.swift in Sources */,
 				045178F12992515100061683 /* DonateModel.swift in Sources */,
 				DBF56B5C28CF4A5700AB0BDF /* HomeCoordinator.swift in Sources */,
@@ -2798,6 +2813,7 @@
 				11B8413D8AEA96EA29A0FF17 /* Pet.swift in Sources */,
 				0028E02D831362905A72161A /* PetI18n+Schema.swift in Sources */,
 				6826AB850FFAF4CC13D042F3 /* PetI18n.swift in Sources */,
+				807874D229D579510005D669 /* FeederShimmerView.swift in Sources */,
 				0DC7F17C09E9C3EA296C308D /* Point+Schema.swift in Sources */,
 				B8E9C0526B1932D00ECDB596 /* Point.swift in Sources */,
 				F0C51AC9C71D7585539B42A1 /* Question+Schema.swift in Sources */,

--- a/animeal/src/Business/Services/Profile/UserProfileService.swift
+++ b/animeal/src/Business/Services/Profile/UserProfileService.swift
@@ -9,6 +9,8 @@ final class UserProfileService: UserProfileServiceProtocol {
     // MARK: - Private properties
     private let converter: UserProfileAmplifyConverting & AmplifyUserProfileConverting
     private let userValidationModel: UserProfileValidationModel
+    private var cachedUserNames: [String: String]?
+    private var userNamesNextToken: String?
 
     // MARK: - Initialization
     init(
@@ -118,6 +120,81 @@ final class UserProfileService: UserProfileServiceProtocol {
             throw converter.convertAmplifyError(error)
         } catch {
             throw UserProfileError.unknown("Something went wrong.")
+        }
+    }
+
+    func fetchUserNames(for userIds: [String]) async throws -> [String: String] {
+        if let cachedUserNames = cachedUserNames, userIds.allSatisfy({ cachedUserNames.keys.contains($0) }) {
+            return cachedUserNames
+        }
+        let path = "/listUsers"
+        do {
+            cachedUserNames = [:]
+            var userNames: [String: String] = [:]
+            var nextToken: String? = userNamesNextToken ?? ""
+            while nextToken != nil {
+                var query: [String: String] = ["limit": "60"]
+                if let nextToken = nextToken, !nextToken.isEmpty {
+                    query["token"] = nextToken.urlPercentEncoding()
+                }
+                let request = RESTRequest(path: path, queryParameters: query, body: nil)
+                let result = try await Amplify.API.get(request: request)
+                let list: UserList = try JSONDecoder().decode(responseBody: result)
+                let userNamesBatch: [String: String] = list.users.reduce(into: [:]) { dict, item in
+                    dict[item.id] = item.fullUserName
+                }
+
+                userNames.merge(userNamesBatch, uniquingKeysWith: { _, new in new })
+                cachedUserNames = userNames
+
+                nextToken = list.nextToken
+                userNamesNextToken = nextToken
+            }
+            return userNames
+        } catch {
+            throw UserProfileError.unknown("Something went wrong.")
+        }
+    }
+
+    private struct UserList: Decodable {
+        let users: [UserListItem]
+        let nextToken: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case users = "Users"
+            case nextToken = "NextToken"
+        }
+    }
+
+    private struct UserListItem: Decodable {
+        let id: String
+        let attributes: [String: String]
+
+        private enum CodingKeys: String, CodingKey {
+            case id = "Username"
+            case attributes = "Attributes"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.id = try container.decode(String.self, forKey: .id)
+
+            var attributesContainer = try container.nestedUnkeyedContainer(forKey: .attributes)
+            var attributes: [String: String] = [:]
+            while !attributesContainer.isAtEnd {
+                guard let item = try? attributesContainer.decode([String: String].self),
+                      let name = item["Name"], let value = item["Value"] else {
+                    continue
+                }
+                attributes[name] = value
+            }
+            self.attributes = attributes
+        }
+
+        var fullUserName: String {
+            let firstName = attributes["name"]
+            let lastName = attributes["family_name"]
+            return [firstName, lastName].compactMap { $0 }.joined(separator: " ")
         }
     }
 }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
@@ -27,9 +27,11 @@ protocol FeedingPointDetailsViewInteraction: AnyObject {
 @MainActor
 protocol FeedingPointDetailsViewState: AnyObject {
     var onContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointDetailsViewItem) -> Void)? { get set }
+    var onFeedingHistoryHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointFeeders) -> Void)? { get set }
     var onMediaContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointMediaContent) -> Void)? { get set }
     var onFavoriteMutationFailed: (() -> Void)? { get set }
     var showOnMapAction: ButtonView.Model? { get }
+    var shimmerScheduler: ShimmerViewScheduler { get }
 }
 
 // MARK: - Model
@@ -39,6 +41,7 @@ protocol FeedingPointDetailsModelProtocol: AnyObject {
     var onFeedingPointChange: ((FeedingPointDetailsModel.PointContent) -> Void)? { get set }
 
     func fetchFeedingPoint(_ completion: ((FeedingPointDetailsModel.PointContent) -> Void)?)
+    func fetchFeedingHistory(_ completion: (([FeedingPointDetailsModel.Feeder]) -> Void)?)
     func fetchMediaContent(key: String, completion: ((Data?) -> Void)?)
     func mutateFavorite() async throws -> Bool
 }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
@@ -12,6 +12,7 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
 
     // MARK: - State
     var onContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointDetailsViewItem) -> Void)?
+    var onFeedingHistoryHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointFeeders) -> Void)?
     var onMediaContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointMediaContent) -> Void)?
     var onFavoriteMutationFailed: (() -> Void)?
 
@@ -25,6 +26,8 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
             title: L10n.Action.showOnMap
         )
     }
+
+    let shimmerScheduler = ShimmerViewScheduler()
 
     // MARK: - Initialization
     init(
@@ -49,6 +52,11 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
                 self?.updateContent(content)
             }
         }
+        model.fetchFeedingHistory { [weak self] content in
+            DispatchQueue.main.async {
+                self?.updateFeedingHistoryContent(content)
+            }
+        }
         model.onFeedingPointChange = { [weak self] content in
             DispatchQueue.main.async {
                 self?.updateContent(content)
@@ -70,6 +78,11 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
     private func updateContent(_ modelContent: FeedingPointDetailsModel.PointContent) {
         loadMediaContent(modelContent.content.header.cover)
         onContentHaveBeenPrepared?(contentMapper.mapFeedingPoint(modelContent))
+    }
+
+    private func updateFeedingHistoryContent(_ modelContent: [FeedingPointDetailsModel.Feeder]) {
+        let mappedContent = contentMapper.mapFeedingHistory(modelContent)
+        onFeedingHistoryHaveBeenPrepared?(mappedContent)
     }
 
     // MARK: - Interaction

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
@@ -61,6 +61,32 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
         }
     }
 
+    func fetchFeedingHistory(_ completion: (([FeedingPointDetailsModel.Feeder]) -> Void)?) {
+        guard let fullFeedingPoint = context.feedingPointsService.storedFeedingPoints.first(where: { point in
+            point.feedingPoint.id == self.feedingPointId
+        }) else {
+            return
+        }
+
+        Task {
+            let history = try await self.fetchFeedingHistory()
+            completion?(history)
+        }
+    }
+
+    func fetchFeedingHistory() async throws -> [FeedingPointDetailsModel.Feeder] {
+        guard let fullFeedingPoint = context.feedingPointsService.storedFeedingPoints.first(where: { point in
+            point.feedingPoint.id == self.feedingPointId
+        }) else {
+            return []
+        }
+
+        let history = try await context.feedingPointsService.fetchFeedingHistory(for: fullFeedingPoint.identifier)
+        let historyUsers = history.map { $0.userId }
+        let namesMap = try await context.profileService.fetchUserNames(for: historyUsers)
+        return mapper.map(history: history, namesMap: namesMap)[..<5].map { $0 }
+    }
+
     func mutateFavorite() async throws -> Bool {
         guard let feedingPoint = cachedFeedingPoint else {
             return false

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
@@ -3,16 +3,27 @@ import UIComponents
 import Style
 
 final class FeedingPointDetailsViewController: UIViewController, FeedingPointDetailsViewable {
+
+    public enum Constants {
+        static let stackSpacing: CGFloat = 16
+    }
+
     // MARK: - Properties
     private let contentContainer: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 16
+        stackView.spacing = Constants.stackSpacing
         return stackView
     }()
     private let buttonContainer: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
+        return stackView
+    }()
+    private let feedingHistoryContainer: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = Constants.stackSpacing
         return stackView
     }()
     private let pointDetailsView = FeedingPointDetailsView()
@@ -42,6 +53,10 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
     private func bind() {
         viewModel.onContentHaveBeenPrepared = { [weak self] content in
             self?.applyFeedingPointContent(content)
+        }
+
+        viewModel.onFeedingHistoryHaveBeenPrepared = { [weak self] content in
+            self?.applyFeedingHistoryContent(content)
         }
 
         viewModel.onMediaContentHaveBeenPrepared = { [weak self] content in
@@ -116,23 +131,11 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
         contentContainer.addArrangedSubview(paragraphView)
         paragraphView.configure(content.placeDescription)
 
-        if !content.feedingPointFeeders.feeders.isEmpty {
-            let title = TextTitleView()
-            title.configure(TextTitleView.Model(title: content.feedingPointFeeders.title))
-            contentContainer.addArrangedSubview(title)
+        let feedingHistoryShimmerView = FeedingHistoryShimmerView()
+        feedingHistoryContainer.addArrangedSubview(feedingHistoryShimmerView)
+        feedingHistoryShimmerView.startAnimation(scheduler: viewModel.shimmerScheduler)
 
-            content.feedingPointFeeders.feeders.forEach { feeder in
-                let view = FeederView()
-                view.configure(
-                    FeederView.Model(
-                        title: feeder.name,
-                        subtitle: feeder.lastFeeded,
-                        icon: Asset.Images.feederPlaceholderIcon.image
-                    )
-                )
-                contentContainer.addArrangedSubview(view)
-            }
-        }
+        contentContainer.addArrangedSubview(feedingHistoryContainer)
 
         contentContainer.addArrangedSubview(UIView())
 
@@ -156,5 +159,28 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
         }
         button.configure(content.action.model)
         buttonContainer.addArrangedSubview(button)
+    }
+
+    func applyFeedingHistoryContent(
+        _ content: FeedingPointDetailsViewMapper.FeedingPointFeeders
+    ) {
+        feedingHistoryContainer.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        if !content.feeders.isEmpty {
+            let title = TextTitleView()
+            title.configure(TextTitleView.Model(title: content.title))
+            feedingHistoryContainer.addArrangedSubview(title)
+
+            content.feeders.forEach { feeder in
+                let view = FeederView()
+                view.configure(
+                    FeederView.Model(
+                        title: feeder.name,
+                        subtitle: feeder.lastFeeded,
+                        icon: Asset.Images.feederPlaceholderIcon.image
+                    )
+                )
+                feedingHistoryContainer.addArrangedSubview(view)
+            }
+        }
     }
 }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewMapper.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewMapper.swift
@@ -10,6 +10,9 @@ protocol FeedingPointDetailsViewMappable {
     func mapFeedingPointMediaContent(
         _ input: Data?
     ) -> FeedingPointDetailsViewMapper.FeedingPointMediaContent?
+    func mapFeedingHistory(
+        _ input: [FeedingPointDetailsModel.Feeder]
+    ) -> FeedingPointDetailsViewMapper.FeedingPointFeeders
 }
 
 final class FeedingPointDetailsViewMapper: FeedingPointDetailsViewMappable {
@@ -44,6 +47,18 @@ final class FeedingPointDetailsViewMapper: FeedingPointDetailsViewMappable {
     func mapFeedingPointMediaContent(_ input: Data?) -> FeedingPointMediaContent? {
         guard let data = input, let icon = UIImage(data: data) else { return nil }
         return FeedingPointMediaContent(pointDetailsIcon: icon)
+    }
+
+    func mapFeedingHistory(
+        _ input: [FeedingPointDetailsModel.Feeder]
+    ) -> FeedingPointFeeders {
+        let feeders = input.map { feeder in
+            FeedingPointFeeders.Feeder(name: feeder.name, lastFeeded: feeder.lastFeeded)
+        }
+        return FeedingPointFeeders(
+            title: L10n.Text.Header.lastFeeder,
+            feeders: feeders
+        )
     }
 
     private func convert(_ status: FeedingPointDetailsModel.Status) -> StatusView.Model {

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/Shimmers/FeederShimmerView.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/Shimmers/FeederShimmerView.swift
@@ -1,0 +1,71 @@
+//
+//  FeederShimmerView.swift
+//  animeal
+//
+//  Created by Mikhail Churbanov on 3/30/23.
+//
+
+import UIKit
+import UIComponents
+import Style
+
+final class FeederShimmerView: UIView {
+
+    private enum Constants {
+        static let shimmerShortLabelWidth: CGFloat = 90
+        static let shimmerLongLabelWidth: CGFloat = 120
+        static let shimmerLabelDeltaWidth: CGFloat = 20
+        static let shimmerLabelHeight: CGFloat = 20
+        static let shimmerCircleImageRadius: CGFloat = 28
+        static let shimmerLabelCornerRadius: CGFloat = 12
+    }
+
+    public init() {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    func setup() {
+        let imageShimmerView = ShimmerView(animationDirection: .leftRight)
+        addSubview(imageShimmerView.prepareForAutoLayout())
+        imageShimmerView.leadingAnchor ~= leadingAnchor
+        imageShimmerView.topAnchor ~= topAnchor
+        imageShimmerView.bottomAnchor ~= bottomAnchor
+        imageShimmerView.heightAnchor ~= Constants.shimmerCircleImageRadius * 2
+        imageShimmerView.widthAnchor ~= Constants.shimmerCircleImageRadius * 2
+        imageShimmerView.cornerRadius(Constants.shimmerCircleImageRadius)
+
+        let titleShimmerView = ShimmerView(animationDirection: .leftRight)
+        addSubview(titleShimmerView.prepareForAutoLayout())
+        titleShimmerView.topAnchor ~= topAnchor + 4
+        titleShimmerView.leadingAnchor ~= imageShimmerView.trailingAnchor + 16
+        titleShimmerView.widthAnchor ~= randomShimmerShortLabelWidth
+        titleShimmerView.heightAnchor ~= Constants.shimmerLabelHeight
+        titleShimmerView.cornerRadius(Constants.shimmerLabelCornerRadius)
+
+        let subtitleShimmerView = ShimmerView(animationDirection: .leftRight)
+        addSubview(subtitleShimmerView.prepareForAutoLayout())
+        subtitleShimmerView.topAnchor ~= titleShimmerView.bottomAnchor + 8
+        subtitleShimmerView.leadingAnchor ~= titleShimmerView.leadingAnchor
+        subtitleShimmerView.widthAnchor ~= randomShimmerLongLabelWidth
+        subtitleShimmerView.heightAnchor ~= Constants.shimmerLabelHeight
+        subtitleShimmerView.cornerRadius(Constants.shimmerLabelCornerRadius)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private var randomShimmerShortLabelWidth: CGFloat {
+        let minWidth = Constants.shimmerShortLabelWidth
+        let maxWidth = Constants.shimmerShortLabelWidth + Constants.shimmerLabelDeltaWidth
+        return CGFloat.random(in: minWidth...maxWidth)
+    }
+
+    private var randomShimmerLongLabelWidth: CGFloat {
+        let minWidth = Constants.shimmerLongLabelWidth
+        let maxWidth = Constants.shimmerLongLabelWidth + Constants.shimmerLabelDeltaWidth
+        return CGFloat.random(in: minWidth...maxWidth)
+    }
+}
+

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/Shimmers/FeedingHistoryShimmerView.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/Shimmers/FeedingHistoryShimmerView.swift
@@ -1,0 +1,70 @@
+//
+//  FeedingHistoryShimmerView.swift
+//  animeal
+//
+//  Created by Mikhail Churbanov on 3/30/23.
+//
+
+import UIKit
+import UIComponents
+import Style
+
+final class FeedingHistoryShimmerView: UIStackView {
+
+    private enum Constants {
+        static let feederShimmerCount = 3
+    }
+
+    public init() {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setup() {
+        axis = .vertical
+        spacing = FeedingPointDetailsViewController.Constants.stackSpacing
+
+        let titleShimmerView = ShimmerView(animationDirection: .leftRight)
+        titleShimmerView.widthAnchor ~= 80
+        titleShimmerView.heightAnchor ~= 24
+        titleShimmerView.cornerRadius(12)
+        addArrangedSubview(titleShimmerView)
+
+        for _ in 0..<Constants.feederShimmerCount {
+            addArrangedSubview(FeederShimmerView())
+        }
+
+        shimmerSubviews.forEach { $0.apply(style: .shimmer) }
+    }
+
+    func startAnimation(scheduler: ShimmerViewScheduler) {
+        shimmerSubviews.forEach { $0.startAnimation(withScheduler: scheduler) }
+        scheduler.start()
+    }
+}
+
+private extension UIView {
+    var shimmerSubviews: [ShimmerView] {
+        let subviewsTree = subviews + subviews.flatMap { $0.shimmerSubviews }
+        return subviewsTree.compactMap { $0 as? ShimmerView }
+    }
+}
+
+private extension Style where Component == ShimmerView {
+    static var shimmer: Style<ShimmerView> {
+        .init { view in
+            let design = view.designEngine
+            view.backgroundColor = design.colors.backgroundPrimary
+            view.border(
+                color: design.colors.backgroundSecondary,
+                width: .pixel
+            )
+            view.clipsToBounds = true
+            view.shadow()
+        }
+    }
+}


### PR DESCRIPTION
- Added minor fix for "+" in Amplify AdminQuery
- Added fetching of feeders history, current feeding, and feeders user names
- Usernames are cached, cause request is heavy (paginated), refresh is done if new user id is detected or app reloaded
- Mapped all data above to show Feeder history on point details screen
- Added shimmers for Feeder history while loading