### PR TITLE
EPMEDU-1801: Added server date retrieval and it's usage for feeding timer

### DIFF
--- a/animeal.xcodeproj/project.pbxproj
+++ b/animeal.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		80138C16298196980010154A /* AboutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80138C11298196980010154A /* AboutViewModel.swift */; };
 		80138C1929828ACC0010154A /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80138C1829828ACC0010154A /* AboutView.swift */; };
 		80138C1B2982B4B30010154A /* AboutLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80138C1A2982B4B30010154A /* AboutLink.swift */; };
+		801F92D02A15057400BCF0BD /* AMURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801F92CF2A15057400BCF0BD /* AMURLSessionDelegate.swift */; };
+		801F92D22A1505CE00BCF0BD /* NetTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801F92D12A1505CE00BCF0BD /* NetTime.swift */; };
 		8076E8A4298FBC070048B97C /* FeedingFinishedAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076E89F298FBC070048B97C /* FeedingFinishedAssembler.swift */; };
 		8076E8A5298FBC070048B97C /* FeedingFinishedContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076E8A0298FBC070048B97C /* FeedingFinishedContract.swift */; };
 		8076E8A6298FBC070048B97C /* FeedingFinishedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076E8A1298FBC070048B97C /* FeedingFinishedViewController.swift */; };
@@ -424,6 +426,8 @@
 		80138C11298196980010154A /* AboutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewModel.swift; sourceTree = "<group>"; };
 		80138C1829828ACC0010154A /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		80138C1A2982B4B30010154A /* AboutLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutLink.swift; sourceTree = "<group>"; };
+		801F92CF2A15057400BCF0BD /* AMURLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AMURLSessionDelegate.swift; sourceTree = "<group>"; };
+		801F92D12A1505CE00BCF0BD /* NetTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetTime.swift; sourceTree = "<group>"; };
 		8076E89F298FBC070048B97C /* FeedingFinishedAssembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingFinishedAssembler.swift; sourceTree = "<group>"; };
 		8076E8A0298FBC070048B97C /* FeedingFinishedContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingFinishedContract.swift; sourceTree = "<group>"; };
 		8076E8A1298FBC070048B97C /* FeedingFinishedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingFinishedViewController.swift; sourceTree = "<group>"; };
@@ -2079,6 +2083,8 @@
 				8324A2C2296B1EEB00AA5D32 /* NetworkRequestModels.swift */,
 				DBDC6E6F28C73E8F001B359D /* NetworkService.swift */,
 				DB84B31428CA13A60083D98C /* NetworkRequest.swift */,
+				801F92CF2A15057400BCF0BD /* AMURLSessionDelegate.swift */,
+				801F92D12A1505CE00BCF0BD /* NetTime.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -2611,6 +2617,7 @@
 				83C7A99F28E4A11A00F3D219 /* ProfileRoute.swift in Sources */,
 				8354135C290AED2600884430 /* PhoneCodesContract.swift in Sources */,
 				DBC5670528D879D100172FD5 /* FeedingPointDetailsViewMapper.swift in Sources */,
+				801F92D02A15057400BCF0BD /* AMURLSessionDelegate.swift in Sources */,
 				8385DB9E290EAD2900F64BCC /* SearchModelFilter.swift in Sources */,
 				8360D1A3284E954900ACDEDB /* LoginModelOnboardingStep.swift in Sources */,
 				FB001451285A097E00943360 /* ProfileAssembler.swift in Sources */,
@@ -2823,6 +2830,7 @@
 				1F770667D42E31D263AE67AB /* RelationPetFeedingPoint+Schema.swift in Sources */,
 				B8A233D7B15B4A46582895E9 /* RelationPetFeedingPoint.swift in Sources */,
 				74DE171718857E1BDAA82A57 /* RelationUserFeedingPoint+Schema.swift in Sources */,
+				801F92D22A1505CE00BCF0BD /* NetTime.swift in Sources */,
 				C059A696D2F75AE49A266D33 /* RelationUserFeedingPoint.swift in Sources */,
 				FF0D1A35DECA7017DE49AF15 /* RelationUserPet+Schema.swift in Sources */,
 				68EBA811759F197EE338048C /* RelationUserPet.swift in Sources */,

--- a/animeal/AppDelegate.swift
+++ b/animeal/AppDelegate.swift
@@ -62,13 +62,36 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AppDelegateProtocol {
 }
 
 private extension AppDelegate {
+
+    struct URLSessionFactory: URLSessionBehaviorFactory {
+        let configuration: URLSessionConfiguration
+        let delegateQueue: OperationQueue?
+
+        func makeSession(withDelegate delegate: URLSessionBehaviorDelegate?) -> URLSessionBehavior {
+            let urlSessionDelegate = AMURLSessionDelegate(amplifyDelegate: delegate)
+            let session = URLSession(configuration: configuration,
+                                     delegate: urlSessionDelegate,
+                                     delegateQueue: delegateQueue)
+            return session
+        }
+
+    }
+
+    static func makeDefault() -> URLSessionFactory {
+        let configuration = URLSessionConfiguration.default
+        configuration.tlsMinimumSupportedProtocolVersion = .TLSv12
+        configuration.tlsMaximumSupportedProtocolVersion = .TLSv13
+        let factory = URLSessionFactory(configuration: configuration, delegateQueue: nil)
+        return factory
+    }
+
     func configureAmplify() {
         do {
             try Amplify.add(plugin: AWSCognitoAuthPlugin())
             try Amplify.add(plugin: AWSS3StoragePlugin())
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels())
             try Amplify.add(plugin: dataStorePlugin)
-            try Amplify.add(plugin: AWSAPIPlugin())
+            try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AppDelegate.makeDefault()))
             try Amplify.configure()
             try Amplify.API.add(interceptor: UrlQueryPlusFixInterceptor(), for: "AdminQueries")
             Amplify.Logging.logLevel = .verbose

--- a/animeal/src/Business/Networking/AMURLSessionDelegate.swift
+++ b/animeal/src/Business/Networking/AMURLSessionDelegate.swift
@@ -1,0 +1,84 @@
+//
+//  AMURLSessionDelegate.swift
+//  animeal
+//
+//  Created by Mikhail Churbanov on 5/17/23.
+//
+
+import Foundation
+import AWSAPIPlugin
+
+public typealias AuthChallengeDispositionHandler = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+
+class AMURLSessionDelegate: NSObject {
+    
+    private let amplifyDelegate: URLSessionBehaviorDelegate?
+
+    private var responseDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "EEE, d MMM yyyy HH:mm:ss ZZZ"
+        return formatter
+    }()
+
+    init(amplifyDelegate: URLSessionBehaviorDelegate?) {
+        self.amplifyDelegate = amplifyDelegate
+    }
+}
+
+// MARK: - Server time extraction from headers
+
+extension AMURLSessionDelegate: URLSessionDataDelegate {
+
+    @objc public func urlSession(_ session: URLSession,
+                                 dataTask: URLSessionDataTask,
+                                 didReceive data: Data) {
+
+        let httpResponse = dataTask.response as? HTTPURLResponse
+        if let serverDateString = httpResponse?.value(forHTTPHeaderField: "date"),
+           let serverDate = responseDateFormatter.date(from: serverDateString) {
+            NetTime.serverTimeDifference = Date.now.timeIntervalSince(serverDate)
+            NetTime.serverNow = serverDate
+        }
+
+        // Pass further to amplify default handler
+        amplifyDelegate?.urlSessionBehavior(session,
+                                            dataTaskBehavior: dataTask,
+                                            didReceive: data)
+    }
+}
+
+// MARK: - Default handling of other required methods
+
+extension AMURLSessionDelegate: URLSessionDelegate {
+
+    @objc public func urlSession(_ session: URLSession,
+                                 didReceive challenge: URLAuthenticationChallenge,
+                                 completionHandler: @escaping AuthChallengeDispositionHandler) {
+
+        completionHandler(.performDefaultHandling, nil)
+    }
+}
+
+extension AMURLSessionDelegate: URLSessionTaskDelegate {
+
+    @objc public func urlSession(_ session: URLSession,
+                                 task: URLSessionTask,
+                                 didReceive challenge: URLAuthenticationChallenge,
+                                 completionHandler: @escaping AuthChallengeDispositionHandler) {
+
+        completionHandler(.performDefaultHandling, nil)
+    }
+
+    @objc public func urlSession(_ session: URLSession,
+                                 task: URLSessionTask,
+                                 didCompleteWithError error: Error?) {
+
+        amplifyDelegate?.urlSessionBehavior(
+            session,
+            dataTaskBehavior: task,
+            didCompleteWithError: error
+        )
+    }
+}

--- a/animeal/src/Business/Networking/NetTime.swift
+++ b/animeal/src/Business/Networking/NetTime.swift
@@ -1,0 +1,16 @@
+//
+//  NetTime.swift
+//  animeal
+//
+//  Created by Mikhail Churbanov on 5/17/23.
+//
+
+import Foundation
+
+final class NetTime {
+    public static var serverTimeDifference: TimeInterval = 0
+    public static var serverNow: Date = Date.now
+    public static var now: Date {
+        return Date.now - serverTimeDifference
+    }
+}

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModelMapper.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModelMapper.swift
@@ -51,14 +51,14 @@ class FeedingPointDetailsModelMapper: FeedingPointDetailsModelMapperProtocol {
             case .inProgress:
                 let minutesLeft = DateFormatter.relativeShort.localizedString(
                     for: historyItem.updatedAt.foundationDate,
-                    relativeTo: Date.now
+                    relativeTo: NetTime.now
                 )
                 lastFeeded = "\(L10n.Feeding.Status.inprogress), \(minutesLeft)"
 
             default:
                 lastFeeded = DateFormatter.relativeFull.localizedString(
                     for: historyItem.updatedAt.foundationDate,
-                    relativeTo: Date.now
+                    relativeTo: NetTime.now
                 )
             }
             return FeedingPointDetailsModel.Feeder(

--- a/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
@@ -31,6 +31,7 @@ protocol HomeModelProtocol: AnyObject {
     func fetchFeedingSnapshot() -> FeedingSnapshot?
     @discardableResult
     func processRejectFeeding() async throws -> FeedingResponse
+    func fetchActiveFeeding() async throws -> Feeding?
 }
 
 // MARK: - ViewModel

--- a/animeal/src/Flows/Main/Modules/Home/Main/HomeViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/HomeViewModel.swift
@@ -107,24 +107,23 @@ final class HomeViewModel: HomeViewModelLifeCycle, HomeViewInteraction, HomeView
     }
 
     func fetchUnfinishedFeeding() async -> Bool {
-        guard
-            let snapshot = model.fetchFeedingSnapshot(),
-            (Date.now - Constants.feedingCountdownTimer) < snapshot.feedStartingDate
-        else {
+        guard let activeFeeding = try? await model.fetchActiveFeeding() else {
             return false
         }
         do {
-            let feedingPoint = try await model.fetchFeedingPoint(snapshot.pointId)
+            let snapshotTimeDiff = model.fetchFeedingSnapshot()?.startingTimeDiff ?? NetTime.serverTimeDifference
+            let timeDiff = snapshotTimeDiff - NetTime.serverTimeDifference
+            let feedingPoint = try await model.fetchFeedingPoint(activeFeeding.feedingPoint.id)
             let pointItemView = feedingPointViewMapper.mapFeedingPoint(feedingPoint)
             // Update view with feedingPoint details
             onFeedingPointsHaveBeenPrepared?([pointItemView])
             // Request build route
-            let timePassSinceFeedingStarted = Date.now - snapshot.feedStartingDate
+            let timePassSinceFeedingStarted = Date.now - activeFeeding.createdAt.foundationDate + timeDiff
             onRouteRequestHaveBeenPrepared?(
                 .init(
                     feedingPointCoordinates: pointItemView.coordinates,
                     countdownTime: Constants.feedingCountdownTimer - timePassSinceFeedingStarted,
-                    feedingPointId: snapshot.pointId,
+                    feedingPointId: activeFeeding.feedingPoint.id,
                     isUnfinishedFeeding: true
                 )
             )

--- a/animeal/src/Flows/Main/Modules/Home/Main/Model/Helpers/FeedingSnapshotStore.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/Model/Helpers/FeedingSnapshotStore.swift
@@ -39,10 +39,12 @@ final class FeedingSnapshotStore: FeedingSnapshotStorable {
 struct FeedingSnapshot: Codable, Storeable {
     let pointId: String
     let feedStartingDate: Date
+    let startingTimeDiff: TimeInterval
 
     init(pointId: String, feedStartingDate: Date) {
         self.pointId = pointId
         self.feedStartingDate = feedStartingDate
+        self.startingTimeDiff = NetTime.serverTimeDifference
     }
 
     var storeData: Data? {

--- a/animeal/src/Flows/Main/Modules/Home/Main/Model/HomeModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/Model/HomeModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Services
 import Combine
+import Amplify
 
 final class HomeModel: HomeModelProtocol {
     typealias Context = DefaultsServiceHolder
@@ -186,6 +187,17 @@ final class HomeModel: HomeModelProtocol {
             throw L10n.Errors.somthingWrong.asBaseError()
         }
     }
+
+    func fetchActiveFeeding() async throws -> Feeding? {
+        guard let userId = await context.profileService.getCurrentUser()?.username else {
+            return nil
+        }
+        let userIdPredicate = QueryPredicateOperation(field: "userId", operator: .equals(userId))
+        return try await context.networkService.query(
+            request: .list(Feeding.self, where: userIdPredicate)
+        ).first
+    }
+
 }
 
 // MARK: Private API


### PR DESCRIPTION
- Added URLSession response interceptor to AWS plugin, this interceptor just parses the "date" HTTP header from backend and saves this information (e.g. time difference between local device time and server time)
- Above-mentioned difference is used to track time changes on device when showing the Feeding Timer to preserve the correct timeout
- Also before using feeding snapshot the active feeding is fetched from backend (this allows to have up-to date time and also fixes problems when feeding disappears after logout/reinstall of app)