### PR TITLE
EPMEDU-1946: fix for last feeders order

### DIFF
--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
@@ -84,10 +84,11 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
         let history = try await context.feedingPointsService.fetchFeedingHistory(for: fullFeedingPoint.identifier)
         guard !history.isEmpty else { return [] }
 
-        let historyUsers = history.map { $0.userId }
+        let sortedByDateHistory = history.sorted(by: { $0.updatedAt > $1.updatedAt })
+        let historyUsers = sortedByDateHistory.map { $0.userId }
         let namesMap = try await context.profileService.fetchUserNames(for: historyUsers)
 
-        let feedingPointDetails = mapper.map(history: history, namesMap: namesMap)
+        let feedingPointDetails = mapper.map(history: sortedByDateHistory, namesMap: namesMap)
         let right = feedingPointDetails.count < 5 ? feedingPointDetails.count : 5
         return feedingPointDetails[..<right].map { $0 }
     }


### PR DESCRIPTION
## What's new:
The [EPMEDU-1696](https://jira.epam.com/jira/browse/EPMEDU-1946) issue is fixed.

**Result:** latest feeder is always displayed on top, other feeders are sorted by date.

## Before:
<img width="477" alt="Screenshot 2023-06-15 at 00 43 11" src="https://github.com/AnimealProject/animeal_iOS/assets/36302791/8fa2ca25-befd-4f92-a60d-b66cf8b416c9">

## After:
<img width="477" alt="Screenshot 2023-06-14 at 23 45 52" src="https://github.com/AnimealProject/animeal_iOS/assets/36302791/feaaea1f-6903-4240-93ca-b166f1b35d4b">