### PR TITLE
EPMEDU-2208: add shimmer view only once

### DIFF
--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
@@ -32,6 +32,7 @@ protocol FeedingPointDetailsViewState: AnyObject {
     var onFavoriteMutationFailed: (() -> Void)? { get set }
     var showOnMapAction: ButtonView.Model? { get }
     var shimmerScheduler: ShimmerViewScheduler { get }
+    var historyInitialized: Bool { get }
 }
 
 // MARK: - Model

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
@@ -15,6 +15,7 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
     var onFeedingHistoryHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointFeeders) -> Void)?
     var onMediaContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointMediaContent) -> Void)?
     var onFavoriteMutationFailed: (() -> Void)?
+    var historyInitialized: Bool = false
 
     // TODO: Move this strange logic to model
     let isOverMap: Bool
@@ -58,6 +59,7 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
         }
         model.fetchFeedingHistory { [weak self] content in
             DispatchQueue.main.async {
+                self?.historyInitialized = true
                 self?.updateFeedingHistoryContent(content)
             }
         }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
@@ -27,6 +27,7 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
         return stackView
     }()
     private let pointDetailsView = FeedingPointDetailsView()
+    private var shimmerAdded = false
 
     // MARK: - Dependencies
     private let viewModel: FeedingPointDetailsViewModelProtocol
@@ -131,10 +132,11 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
         contentContainer.addArrangedSubview(paragraphView)
         paragraphView.configure(content.placeDescription)
 
-        if feedingHistoryContainer.arrangedSubviews.isEmpty {
+        if !self.viewModel.historyInitialized && !self.shimmerAdded {
             let feedingHistoryShimmerView = FeedingHistoryShimmerView()
             feedingHistoryContainer.addArrangedSubview(feedingHistoryShimmerView)
             feedingHistoryShimmerView.startAnimation(scheduler: viewModel.shimmerScheduler)
+            self.shimmerAdded = true
         }
 
         contentContainer.addArrangedSubview(feedingHistoryContainer)


### PR DESCRIPTION
After the discussion with @rinold, we decided to go with this approach:
1. Shimmer view is shown only once per lifetime of `FeedingPointDetailsViewContr
oller`.
2. Shimmer view isn't shown when tapping favorite button.