### PR TITLE
EPMEDU-2149: Feeding point name is missing for Eng

### DIFF
--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModelMapper.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModelMapper.swift
@@ -99,30 +99,19 @@ final class FeedingPointDetailsModelMapper: FeedingPointDetailsModelMapperProtoc
 
 extension FeedingPoint {
     var localizedDescription: String {
-        switch Locale.current.languageCode {
-        case "ka":
-            return description
-        default:
-            return i18n?.first(where: { $0.locale == "en" })?.description ?? .empty
-        }
+        localized?.description ?? description
     }
 
     var localizedName: String {
-        switch Locale.current.languageCode {
-        case "ka":
-            return name
-        default:
-            return i18n?.first(where: { $0.locale == "en" })?.name ?? name
-        }
+        localized?.name ?? name
     }
 
     var localizedCity: String {
-        switch Locale.current.languageCode {
-        case "ka":
-            return city
-        default:
-            return i18n?.first(where: { $0.locale == "en" })?.city ?? .empty
-        }
+        localized?.city ?? city
+    }
+
+    private var localized: FeedingPointI18n? {
+        i18n?.first { $0.locale == Locale.current.languageCode }
     }
 }
 

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModelMapper.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModelMapper.swift
@@ -112,7 +112,7 @@ extension FeedingPoint {
         case "ka":
             return name
         default:
-            return i18n?.first(where: { $0.locale == "en" })?.name ?? .empty
+            return i18n?.first(where: { $0.locale == "en" })?.name ?? name
         }
     }
 


### PR DESCRIPTION
## What's new:
The [EPMEDU-2149](https://jira.epam.com/jira/browse/EPMEDU-2149) issue is fixed. If the localized title of any feeding point is empty the app uses the value for Georgian locale as we agreed with @rinold.

## Before:
<img width="474" alt="Screenshot 2023-08-08 at 19 27 09" src="https://github.com/AnimealProject/animeal_iOS/assets/36302791/b961cce7-91f3-4db5-8ca9-5cdcacd0f272">

## After:
<img width="474" alt="Screenshot 2023-08-08 at 19 25 11" src="https://github.com/AnimealProject/animeal_iOS/assets/36302791/62e1614e-fb80-4ed0-b3d8-12fcf934da97">