### PR TITLE
EPMEDU-2653: Update QuestionMapper.swift

### DIFF
--- a/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/QuestionMapper.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/QuestionMapper.swift
@@ -17,20 +17,14 @@ final class QuestionMapper: QuestionMappable {
 
 private extension Question {
     var localizedValue: String {
-        switch Locale.current.languageCode {
-        case "ka":
-            return value ?? .empty
-        default:
-            return i18n?.first(where: { $0.locale == "en" })?.value ?? .empty
-        }
+        localized?.value ?? value ?? .empty
     }
 
     var localizedAnswer: String {
-        switch Locale.current.languageCode {
-        case "ka":
-            return answer ?? .empty
-        default:
-            return i18n?.first(where: { $0.locale == "en" })?.answer ?? .empty
-        }
+        localized?.answer ?? answer ?? .empty
+    }
+
+    private var localized: QuestionI18n? {
+        i18n?.first { $0.locale == Locale.current.languageCode }
     }
 }


### PR DESCRIPTION
In the FAQ response some of the values did not have it's corresponding localised strings but had it's non localised counterpart. Hence default to the non localised counterpart. In case the localised part is missing. source of idea is one of the previous pr's on a similar topic https://github.com/AnimealProject/animeal_iOS/pull/193

Previous:

<img width="1920" alt="Screenshot 2023-09-06 at 6 44 45 PM" src="https://github.com/AnimealProject/animeal_iOS/assets/13431950/7f9d8e08-d47c-4dbf-b44e-f11222880f28">

After my fix:

<img width="1440" alt="Screenshot 2023-09-07 at 12 04 30 PM" src="https://github.com/AnimealProject/animeal_iOS/assets/13431950/fad84db8-d5ee-4962-90f8-349c40285e55">
