### PR TITLE
EPMEDU-2662-update feeding points selection based on selection updates in search screen

### DIFF
--- a/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
@@ -14,7 +14,8 @@ protocol HomeViewModelOutput: AnyObject {
 protocol HomeModelProtocol: AnyObject {
     // Events
     var onFeedingPointChange: (([HomeModel.FeedingPoint]) -> Void)? { get set }
-
+    var selectedFilter: HomeModel.FilterItemIdentifier { get }
+    var savedFeedingPoints: [HomeModel.FeedingPoint] { get }
     func fetchFeedingPoints() async throws -> [HomeModel.FeedingPoint]
     func fetchFilterItems(_ completion: (([HomeModel.FilterItem]) -> Void)?)
     func fetchFeedingAction(request: HomeModel.FeedingActionRequest) -> HomeModel.FeedingAction
@@ -44,6 +45,7 @@ protocol HomeViewModelLifeCycle: AnyObject {
     func setup()
     func load()
     func refreshCurrentFeeding()
+    func updateSelectionIfNeeded(for selection: HomeModel.FilterItemIdentifier)
 }
 
 @MainActor

--- a/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
@@ -54,11 +54,20 @@ class HomeViewController: UIViewController {
             self?.viewModel.refreshCurrentFeeding()
         }
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        
         updateCameraEasePadding()
+    }
+
+    /// On view will appear passing the current selected tab to view model.
+    /// to help check if the view needs update in terms of displaying the feeding points on map + tab selection
+    /// - Parameter animated: if the transition was animated.
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let itemIdentifier = HomeModel.FilterItemIdentifier(rawValue: segmentedControl.selectedSegmentIndex) {
+            viewModel.updateSelectionIfNeeded(for: itemIdentifier)
+        }
     }
 }
 


### PR DESCRIPTION


Issue: If the selected feeding points type i.e. cat or dog is updated in search screen. either the update happened via cached data or live data.
update via cached data: no trigger was there to update the home screen feeding point selection
update via live data: there was a trigger to update the home screen feeding point selection but that update the feeding points on the map only and not the selected tab over head.

Implemented the feature as follows:
update via live data: call the method to update the segmented control update via cached data: call the method on view will appear. it check if the current selection on map screen is same as that of the selection recorded in user defaults. If not then call a method to fetch this cached data and update the selection. cached data is used for updates in view will appear as we don't want to call network frequently.

Technical changes:
1. Implement a computed property in home model to support fetching filtered cached data.
2. Implement one method in home view model to fetch cached data and trigger update selection in ui + map
3. expose one computed property to check which is the currently selected filter type in user defaults.
4. on view will appear check if we need to update the ui