### PR TITLE
EPMEDU-2637-remove-logging-Network-service

### DIFF
--- a/animeal/src/Business/Networking/NetworkService.swift
+++ b/animeal/src/Business/Networking/NetworkService.swift
@@ -40,8 +40,8 @@ extension NetworkServiceProtocol {
             do {
                 for try await subscriptionEvent in subscription {
                     switch subscriptionEvent {
-                    case .connection(let subscriptionConnectionState):
-                        logDebug("Subscription connect state is \(subscriptionConnectionState)")
+                    case .connection:
+                        break
                     case .data(let result):
                         switch result {
                         case .success(let modelData):


### PR DESCRIPTION
issue- On application launch our xcode console was complaining for ui method call from background thread. upon investigation found that firebase and crashlytics initialisation was happening after our registering of network services which are using the logging mechanism. this logging is happening in background thread hence trying to initialise the firebase SDK on background thread.

Solution: removing the log
Alternative Solution: if we need logging then we need to initialise the SDK's before setting up our services.

benefits of this change:
1. avoid chances of crash
2. clear way for running unit test via command line. currently we cannot run unit test via our CI/CD systems due to unit test not able to run via command line.

Note: In next pr will run the unit test via command line in our github actions step

Screenshot of Xcode logs:

<img width="1919" alt="Screenshot 2023-08-26 at 4 00 24 PM" src="https://github.com/AnimealProject/animeal_iOS/assets/13431950/e3287866-057c-4301-a3bf-abae5f0dd2d6">

