### PR TITLE
Update Observer in home view controller do not call observer if no route draw is happening

### DIFF
--- a/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
@@ -320,6 +320,7 @@ private extension HomeViewController {
     func toggleRouteAndTimer(isVisible: Bool) {
         if !isVisible {
             feedControl.stopTimer()
+            mapView.didChangeLocation = nil
             mapView.cancelRouteRequest()
         }
         segmentedControl.isHidden = isVisible

--- a/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
@@ -281,11 +281,8 @@ private extension NavigationMapController {
 // MARK: - LocationConsumer delegate conformance
 extension NavigationMapController: LocationConsumer {
     func locationUpdate(newLocation: MapboxMaps.Location) {
-        if currentRoute == nil {
-            didChangeLocation?(newLocation.location, true)
-        } else {
-            didChangeLocation?(newLocation.location, false)
-        }
+        if routeResponse == nil { return } // If no route no route draw.
+        didChangeLocation?(newLocation.location, currentRoute == nil)
     }
 }
 


### PR DESCRIPTION

In navigation map controller, check if route response is nil if yes do not call the location update delegate. In home view controller, when cancel the route request. stop observing for location based changes. the location changes based observer was only working for route draw related work. hence ideally should not disrupt any existing flow.