### PR TITLE
Use CI to run unit tests Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with: 
-          xcode-version: '14.2'
+          xcode-version: '14.3.1'
       - name: Build For Test
         run: |
-          xcodebuild build-for-testing -scheme animeal -project animeal.xcodeproj -destination "platform=iOS Simulator,name=iPhone 14,OS=16.2" -parallelizeTargets -showBuildTimingSummary | xcbeautify --renderer github-actions
+          xcodebuild test -scheme animeal -project animeal.xcodeproj -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" -parallelizeTargets -showBuildTimingSummary | xcbeautify --renderer github-actions


### PR DESCRIPTION
Hello guys,
the motivation to raise this pr is to run unit test on every pr. though we have only 1 unit test running at the moment. it helps us to know if the project builds and runs successfully.
Also update the xcode version to 14.3.1 i.e. latest what we are using as of now.
prepares us to use xcode15 in future.