### PR TITLE
[EPMEDU-1973] Fixed UI suppressing exception and popping view on registration cancel in some cases

### DIFF
--- a/animeal/src/Flows/Profile/ProfileViewModel.swift
+++ b/animeal/src/Flows/Profile/ProfileViewModel.swift
@@ -211,8 +211,12 @@ final class ProfileViewModel: ProfileViewModelProtocol {
                             .no(),
                             .yes(handler: {
                                 Task { [weak self] in
-                                    try? await action()
-                                    self?.coordinator.move(to: .cancel)
+                                    do {
+                                        try await action()
+                                        self?.coordinator.move(to: .cancel)
+                                    } catch {
+                                        // cancelled, stay as is
+                                    }
                                 }
                             })
                         ]


### PR DESCRIPTION
RCA: problem was in try? that was suppressing the error thrown from sign out operation when cancelling it
Solution: catch this exception :)