### PR TITLE
Update ProfileViewModel.swift

### DIFF
--- a/animeal/src/Flows/Profile/ProfileViewModel.swift
+++ b/animeal/src/Flows/Profile/ProfileViewModel.swift
@@ -247,14 +247,8 @@ final class ProfileViewModel: ProfileViewModelProtocol {
 }
 
 private extension ProfileViewModel {
-    func processNextStep(
-        _ nextStep: ProfileModelNextStep,
-        actionIdentifier: String
-    ) {
-        switch nextStep {
-        case .done:
-            coordinator.move(to: .done)
-        case let .confirm(details, attribute, resendMethod):
+    func processNextStep(_ nextStep: ProfileModelNextStep, actionIdentifier: String) {
+        if case let .confirm(details, attribute, resendMethod) = nextStep {
             let completion: (() -> Void)? = { [weak self] in
                 Task { [weak self] in
                     await self?.handleProceedAction(forIdentifier: actionIdentifier)


### PR DESCRIPTION
do not move the co-ordinator to done. as we dont want to go back to more menu screen on profile update action.