### PR TITLE
update mapbox maps ios

### DIFF
--- a/animeal.xcodeproj/project.pbxproj
+++ b/animeal.xcodeproj/project.pbxproj
@@ -3340,8 +3340,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 10.17.0;
+				kind = exactVersion;
+				version = 10.18.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/animeal.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/animeal.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "696503304fe8807bd5af3abb23ef20c051dd8b12",
-        "version" : "23.9.2"
+        "revision" : "c2aa7022afdcf5a070ace4e3b608562101a04690",
+        "version" : "23.10.1"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "255a3d159c710d33ab8a85d15a2842012462f581",
-        "version" : "10.17.0"
+        "revision" : "51f776b11bcff34ced88fcf14e4ed9c568257232",
+        "version" : "10.18.0"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-directions-swift.git",
       "state" : {
-        "revision" : "dffb8fd7c8316ae8d9b79b694be933deba6f544e",
-        "version" : "2.12.0"
+        "revision" : "6512320ee7f0091a4c55abe2bc6414f078da88c8",
+        "version" : "2.14.0"
       }
     },
     {
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "52bb5df80e4a6dd84d61bf9f4fc63a68b30c03e4",
-        "version" : "10.17.0"
+        "revision" : "8ef49bb140bbd5d51917f1e69d4c3949a176c009",
+        "version" : "10.18.2"
       }
     },
     {
@@ -293,8 +293,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/turf-swift.git",
       "state" : {
-        "revision" : "f0afe204b4266337066a436becab62fdd2b32378",
-        "version" : "2.7.0"
+        "revision" : "213050191cfcb3d5aa76e1fa90c6ff1e182a42ca",
+        "version" : "2.8.0"
       }
     }
   ],

--- a/animeal/src/Business/Services/Profile/UserProfileAmplifyConverter.swift
+++ b/animeal/src/Business/Services/Profile/UserProfileAmplifyConverter.swift
@@ -195,7 +195,8 @@ struct UserProfileAmplifyConverter: UserProfileAmplifyConverting, AmplifyUserPro
                 guard let key = convertAuthUserAttributeKey(key) else { return nil }
                 return (key, convertUpdateAttributeResult(value))
             }
-        return Dictionary(uniqueKeysWithValues: converted)
+        let condensed = Dictionary(uniqueKeysWithValues: converted)
+        return condensed
     }
 
     func convertCodeDeliveryDetails(_ codeDeliveryDetails: AuthCodeDeliveryDetails) -> UserProfileCodeDeliveryDetails {


### PR DESCRIPTION
updating max box maps iOS for xcode16 was needed due to some build failures. will update the CI pipeline as well in the next step.