### PR TITLE
[fix/EPMEDU-3826] Show answer as-is instead of localized answer

### DIFF
--- a/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/QuestionMapper.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/QuestionMapper.swift
@@ -10,7 +10,7 @@ final class QuestionMapper: QuestionMappable {
         FAQModel.Question(
             id: input.id,
             question: input.localizedValue,
-            answer: input.localizedAnswer
+            answer: input.answer ?? input.localizedAnswer
         )
     }
 }


### PR DESCRIPTION
The app is showing the localized answer. However, that's not the desired behavior. Based on the conversation I had with Alicia, they want to show the answers 'as-is'