### PR TITLE
Update unit-test.yml

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -74,11 +74,3 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild test -scheme animeal -project animeal.xcodeproj -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5" -parallelizeTargets -showBuildTimingSummary 2>&1 | xcbeautify --renderer github-actions
-          
-          BUILD_EXIT_CODE=${PIPESTATUS[0]}
-          if [ $BUILD_EXIT_CODE -ne 0 ]; then
-            echo "::error::Build failed with exit code $BUILD_EXIT_CODE"
-            exit $BUILD_EXIT_CODE
-          fi
-          
-          echo "✅ Build and tests passed successfully"


### PR DESCRIPTION
This pull request simplifies the unit test workflow by removing redundant build exit code handling and success messaging from the `.github/workflows/unit-test.yml` file.

Workflow simplification:

* Removed manual checking of the build exit code and explicit error/success messages, relying instead on the default behavior of the workflow to report failures.