### PR TITLE
EPMEDU-4842: Fix inactive link to the WEB on About page

### DIFF
--- a/animeal/src/Flows/Main/Modules/More/Submodules/About/View/AboutLink.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/About/View/AboutLink.swift
@@ -55,7 +55,7 @@ extension AboutLink {
             return "linkedin://company/animalprojectgeorgia"
 
         case .website:
-            return nil
+            return "https://animalproject.ge/"
         }
     }
 
@@ -71,7 +71,7 @@ extension AboutLink {
             return "https://www.linkedin.com/company/animalprojectgeorgia/"
 
         case .website:
-            return nil
+            return "https://animalproject.ge/"
         }
     }
 }


### PR DESCRIPTION
- Fixed inactive link to the WEB on the About page
- Verified that the link now opens correctly
- Tested on simulator