### PR TITLE
EPMEDU-4846: Pet's icon on the map is unclickable

### DIFF
--- a/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/HomeViewController.swift
@@ -365,9 +365,9 @@ private extension HomeViewController {
         view.addSubview(mapView.view)
         mapView.mapboxMap.loadStyleURI(styleURI)
 
-        mapView.didTapAnnotations = { [weak self] in
-            let points = Set($0.map(\.id))
-            self?.viewModel.handleActionEvent(.tapFeedingPoints(Array(points)))
+        mapView.didTapAnnotations = { [weak self] annotations in
+            guard let tappedAnnotation = annotations.first else { return }
+            self?.viewModel.handleActionEvent(.tapFeedingPoints([tappedAnnotation.id]))
         }
 
         mapView.cameraAnimationQueue.append {

--- a/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
@@ -36,6 +36,9 @@ class NavigationMapController: NavigationViewControllerDelegate {
     var didChangeLocation: ((CLLocation, Bool) -> Void)?
     var didTapAnnotations: (([Annotation]) -> Void)?
 
+    private var lastTapLocation: CGPoint?
+    private weak var tapGestureRecognizer: UITapGestureRecognizer?
+
     var view: UIView {
         return navigationMapView
     }
@@ -84,6 +87,20 @@ class NavigationMapController: NavigationViewControllerDelegate {
         }
 
         annotationManager.point.delegate = self
+        setupTapGesture()
+    }
+
+    private func setupTapGesture() {
+        let tapGesture = UITapGestureRecognizer()
+        tapGesture.addTarget(self, action: #selector(handleMapTap(_:)))
+        tapGesture.cancelsTouchesInView = false
+        navigationMapView.mapView.addGestureRecognizer(tapGesture)
+        tapGestureRecognizer = tapGesture
+    }
+
+    @objc private func handleMapTap(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        lastTapLocation = gesture.location(in: navigationMapView.mapView)
     }
 
     // MARK: - Public API
@@ -315,6 +332,44 @@ extension  NavigationMapController: NavigationMapViewDelegate {
 // MARK: - AnnotationInteractionDelegate conformance
 extension NavigationMapController: AnnotationInteractionDelegate {
     func annotationManager(_ manager: AnnotationManager, didDetectTappedAnnotations annotations: [Annotation]) {
-        didTapAnnotations?(annotations)
+        guard !annotations.isEmpty else { return }
+
+        let sortedAnnotations: [Annotation]
+        if let tapLocation = lastTapLocation, annotations.count > 1 {
+            let tapCoordinate = navigationMapView.mapView.mapboxMap.coordinate(for: tapLocation)
+            sortedAnnotations = annotations.sorted { annotation1, annotation2 in
+                distance(from: tapCoordinate, to: annotation1) < distance(from: tapCoordinate, to: annotation2)
+            }
+        } else {
+            sortedAnnotations = annotations
+        }
+
+        lastTapLocation = nil
+        didTapAnnotations?(sortedAnnotations)
+    }
+
+    private func distance(from coordinate: CLLocationCoordinate2D, to annotation: Annotation) -> CLLocationDistance {
+        guard let annotationCoordinate = getCoordinate(from: annotation) else {
+            return .infinity
+        }
+        return coordinate.distance(to: annotationCoordinate)
+    }
+
+    private func getCoordinate(from annotation: Annotation) -> CLLocationCoordinate2D? {
+        switch annotation.geometry {
+        case .point(let point):
+            return point.coordinates
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - CLLocationCoordinate2D Extension
+private extension CLLocationCoordinate2D {
+    func distance(to coordinate: CLLocationCoordinate2D) -> CLLocationDistance {
+        let location1 = CLLocation(latitude: latitude, longitude: longitude)
+        let location2 = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        return location1.distance(from: location2)
     }
 }

--- a/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
@@ -359,6 +359,8 @@ extension NavigationMapController: AnnotationInteractionDelegate {
         switch annotation.geometry {
         case .point(let point):
             return point.coordinates
+        case .polygon(let polygon):
+            return polygon.center
         default:
             return nil
         }

--- a/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/View/NavigationMapController.swift
@@ -90,6 +90,13 @@ class NavigationMapController: NavigationViewControllerDelegate {
         setupTapGesture()
     }
 
+    deinit {
+        if let tapGestureRecognizer {
+            view.removeGestureRecognizer(tapGestureRecognizer)
+
+        }
+    }
+
     private func setupTapGesture() {
         let tapGesture = UITapGestureRecognizer()
         tapGesture.addTarget(self, action: #selector(handleMapTap(_:)))
@@ -332,7 +339,10 @@ extension  NavigationMapController: NavigationMapViewDelegate {
 // MARK: - AnnotationInteractionDelegate conformance
 extension NavigationMapController: AnnotationInteractionDelegate {
     func annotationManager(_ manager: AnnotationManager, didDetectTappedAnnotations annotations: [Annotation]) {
-        guard !annotations.isEmpty else { return }
+        guard !annotations.isEmpty else {
+            lastTapLocation = nil
+            return
+        }
 
         let sortedAnnotations: [Annotation]
         if let tapLocation = lastTapLocation, annotations.count > 1 {


### PR DESCRIPTION
Fixes tap handling on the Home map by prioritizing the closest annotation to the user’s tap, addressing cases where multiple annotations are detected for a single tap (e.g., overlapping markers).

<img width="514" height="1038" alt="Screenshot 2026-02-17 at 19 28 07" src="https://github.com/user-attachments/assets/7fa6f33d-e435-459c-8271-114d8790f05c" />

- sort detected tapped annotations by distance to the tap coordinate before forwarding to the Home module.