### PR TITLE
sync feeding snapshot to support multi-device sessions

### DIFF
--- a/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/HomeContract.swift
@@ -30,6 +30,7 @@ protocol HomeModelProtocol: AnyObject {
     func processCancelFeeding() async throws -> FeedingResponse
     func processFinishFeeding(imageKeys: [String]) async throws -> FeedingResponse
     func fetchFeedingSnapshot() -> FeedingSnapshot?
+    func updateFeedingSnapshot(id: String, date: Date)
     @discardableResult
     func processRejectFeeding() async throws -> FeedingResponse
     func fetchActiveFeeding() async throws -> Feeding?

--- a/animeal/src/Flows/Main/Modules/Home/Main/HomeViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/HomeViewModel.swift
@@ -132,6 +132,9 @@ final class HomeViewModel: HomeViewModelLifeCycle, HomeViewInteraction, HomeView
             return false
         }
         do {
+            let creationDate = activeFeeding.createdAt.foundationDate
+            model.updateFeedingSnapshot(id: activeFeeding.feedingPointFeedingsId, date: creationDate)
+            
             let snapshotTimeDiff = model.fetchFeedingSnapshot()?.startingTimeDiff ?? NetTime.serverTimeDifference
             let timeDiff = snapshotTimeDiff - NetTime.serverTimeDifference
             let feedingPoint = try await model.fetchFeedingPoint(activeFeeding.feedingPointFeedingsId)

--- a/animeal/src/Flows/Main/Modules/Home/Main/Model/HomeModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/Model/HomeModel.swift
@@ -115,6 +115,10 @@ final class HomeModel: HomeModelProtocol {
     func fetchFeedingSnapshot() -> FeedingSnapshot? {
         return snapshotStore.snaphot
     }
+    
+    func updateFeedingSnapshot(id: String, date: Date) {
+        snapshotStore.save(id, date: date)
+    }
 
     @discardableResult
     func processCancelFeeding() async throws -> FeedingResponse {


### PR DESCRIPTION
## Pull Request overview
**Fix multi-device feeding state — enable finish & cancel on secondary devices**

---

## Problem

Users who started feeding on one device could see “Feeding in progress” on another device but were unable to **finish or cancel** the feeding.

Root cause:

- Feeding actions relied on a locally stored snapshot
- On a new device the snapshot did not exist
- Mutations were sent with an empty or invalid identifier
- As a result, finish and cancel operations failed despite the feeding being active on the backend

---

## Summary

This PR introduces a minimal, non-breaking fix:

- Synchronizes the local feeding snapshot with the server’s active feeding when an unfinished feeding is detected
- Ensures the correct identifier is available for finish and cancel actions on any device -
 
---

## Changes

| File | What changed |
|------|--------------|
| `HomeModel.swift` | Added `updateFeedingSnapshot(id:date:)` to refresh snapshot from server data |
| `HomeContract.swift` | Exposed `updateFeedingSnapshot` in protocol |
| `HomeViewModel.swift` | Updates snapshot when unfinished feeding is detected |

---

## 🧠 How it works (High level)

1. App launches or Home loads
2. Active feeding is fetched from the backend
3. Local snapshot is refreshed using server data
4. UI resumes feeding state safely on any device
5. Finish and cancel actions now use a valid identifier

---

## How to test

### Multi-device scenario

1. Start feeding on Device A
2. Open the app on Device B with the same account
3. Feeding should appear as **in progress**
4. Try to finish feeding → should succeed
5. Start feeding again and try cancel → should succeed

---

## Notes

 This PR intentionally avoids removing or redesigning the snapshot system to keep changes minimal and safe. A future refactor may further simplify feeding session management if needed.
 
 ---



# Device 1 (Starting Feeding)
 <img width="250" height="510" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 15 28 59" src="https://github.com/user-attachments/assets/eb23d9c0-13b8-4c77-a342-f96f916d42b5" />

# Device 2 (Finishing Feeding)
<img width="240" height="510" alt="Simulator Screenshot - iPhone 15 Pro - 2026-03-02 at 15 37 58" src="https://github.com/user-attachments/assets/c7d649d2-26a9-4b76-a298-3fc3f791d1da" />
<img width="240" height="510" alt="Simulator Screenshot - iPhone 15 Pro - 2026-03-02 at 15 38 07" src="https://github.com/user-attachments/assets/a6fff177-79a7-4f1d-aa6b-d7034bbe5d16" />
<img width="240" height="510" alt="Simulator Screenshot - iPhone 15 Pro - 2026-03-02 at 15 38 26" src="https://github.com/user-attachments/assets/fd31b43b-0b3f-43d9-8ce2-2f00ac63a0ff" />