### PR TITLE
Feature/epmedu 4867 faq ordering

### DIFF
--- a/amplify/generated/models/AmplifyModels.swift
+++ b/amplify/generated/models/AmplifyModels.swift
@@ -5,7 +5,7 @@ import Foundation
 // Contains the set of classes that conforms to the `Model` protocol. 
 
 final public class AmplifyModels: AmplifyModelRegistration {
-  public let version: String = "7c733dbb9c6ae98d269db3c38b9230ca"
+  public let version: String = "0e6baff3a4912a30ad79257d8b3b84b5"
   
   public func registerModels(registry: ModelRegistry.Type) {
     ModelRegistry.register(modelType: Pet.self)

--- a/amplify/generated/models/FeedingPoint+Schema.swift
+++ b/amplify/generated/models/FeedingPoint+Schema.swift
@@ -29,6 +29,7 @@ extension FeedingPoint {
     case category
     case users
     case cover
+    case disabled
     case feedingPointCategoryId
   }
   
@@ -75,6 +76,7 @@ extension FeedingPoint {
       .hasOne(feedingPoint.category, is: .optional, ofType: Category.self, associatedWith: Category.keys.id, targetName: "feedingPointCategoryId"),
       .hasMany(feedingPoint.users, is: .optional, ofType: RelationUserFeedingPoint.self, associatedWith: RelationUserFeedingPoint.keys.feedingPoint),
       .field(feedingPoint.cover, is: .optional, ofType: .string),
+      .field(feedingPoint.disabled, is: .optional, ofType: .bool),
       .field(feedingPoint.feedingPointCategoryId, is: .optional, ofType: .string)
     )
     }

--- a/amplify/generated/models/FeedingPoint.swift
+++ b/amplify/generated/models/FeedingPoint.swift
@@ -27,6 +27,7 @@ public struct FeedingPoint: Model {
   public var category: Category?
   public var users: List<RelationUserFeedingPoint>?
   public var cover: String?
+  public var disabled: Bool?
   public var feedingPointCategoryId: String?
   
   public init(id: String = UUID().uuidString,
@@ -53,6 +54,7 @@ public struct FeedingPoint: Model {
       category: Category? = nil,
       users: List<RelationUserFeedingPoint> = [],
       cover: String? = nil,
+      disabled: Bool? = nil,
       feedingPointCategoryId: String? = nil) {
       self.id = id
       self.name = name
@@ -78,6 +80,7 @@ public struct FeedingPoint: Model {
       self.category = category
       self.users = users
       self.cover = cover
+      self.disabled = disabled
       self.feedingPointCategoryId = feedingPointCategoryId
   }
 }

--- a/amplify/generated/models/Question+Schema.swift
+++ b/amplify/generated/models/Question+Schema.swift
@@ -8,6 +8,7 @@ extension Question {
     case id
     case value
     case answer
+    case orderNum
     case i18n
     case createdAt
     case updatedAt
@@ -38,6 +39,7 @@ extension Question {
       .id(),
       .field(question.value, is: .optional, ofType: .string),
       .field(question.answer, is: .optional, ofType: .string),
+      .field(question.orderNum, is: .optional, ofType: .int),
       .field(question.i18n, is: .optional, ofType: .embeddedCollection(of: QuestionI18n.self)),
       .field(question.createdAt, is: .required, ofType: .dateTime),
       .field(question.updatedAt, is: .required, ofType: .dateTime),

--- a/amplify/generated/models/Question.swift
+++ b/amplify/generated/models/Question.swift
@@ -6,6 +6,7 @@ public struct Question: Model {
   public let id: String
   public var value: String?
   public var answer: String?
+  public var orderNum: Int?
   public var i18n: [QuestionI18n]?
   public var createdAt: Temporal.DateTime
   public var updatedAt: Temporal.DateTime
@@ -16,6 +17,7 @@ public struct Question: Model {
   public init(id: String = UUID().uuidString,
       value: String? = nil,
       answer: String? = nil,
+      orderNum: Int? = nil,
       i18n: [QuestionI18n]? = nil,
       createdAt: Temporal.DateTime,
       updatedAt: Temporal.DateTime,
@@ -25,6 +27,7 @@ public struct Question: Model {
       self.id = id
       self.value = value
       self.answer = answer
+      self.orderNum = orderNum
       self.i18n = i18n
       self.createdAt = createdAt
       self.updatedAt = updatedAt

--- a/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/FAQModel.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/FAQModel.swift
@@ -23,9 +23,19 @@ final class FAQModel: FAQModelProtocol {
     
     private func orderQuestions(_ questions: [animeal.Question]) -> [animeal.Question] {
         let ordered = questions
-            .filter { $0.orderNum != nil }
-            .sorted(by: { $0.orderNum! < $1.orderNum! })
+            .compactMap { question -> (animeal.Question, Int)? in
+                guard let orderNumber = question.orderNum else { return nil }
+                return (question, orderNumber)
+            }
+            .sorted { $0.1 < $1.1 }
+            .map { $0.0 }
         let unordered = questions.filter { $0.orderNum == nil }
+            .compactMap { question -> (animeal.Question, String)? in
+                guard let questionValue = question.value else { return nil }
+                return (question, questionValue)
+            }
+            .sorted { $0.1.localizedStandardCompare($1.1) == .orderedAscending }
+            .map{ $0.0 }
         return ordered + unordered
     }
 }

--- a/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/FAQModel.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/Model/FAQModel.swift
@@ -17,7 +17,16 @@ final class FAQModel: FAQModelProtocol {
 
     func fetchQuestions() async throws -> [Question] {
         let questions = try await networkService.query(request: .list(animeal.Question.self))
-        return questions.map(mapper.mapQuestion)
+        let ordered = orderQuestions(questions)
+        return ordered.map(mapper.mapQuestion)
+    }
+    
+    private func orderQuestions(_ questions: [animeal.Question]) -> [animeal.Question] {
+        let ordered = questions
+            .filter { $0.orderNum != nil }
+            .sorted(by: { $0.orderNum! < $1.orderNum! })
+        let unordered = questions.filter { $0.orderNum == nil }
+        return ordered + unordered
     }
 }
 


### PR DESCRIPTION
## Pull Request overview
**Regenerate Amplify models and integrate FAQ `orderNum` field with deterministic sorting**

---

## Problem

The FAQ backend schema was updated to include a new optional field: `orderNum`.

However, the local iOS project did not reflect this change because the generated Amplify Swift models were outdated. As a result:

- `Question` model did not contain `orderNum`
- FAQ ordering could not be implemented
- Schema and generated models were out of sync

Root cause: Amplify models were not regenerated after schema updates, causing stale generated files in `amplify/generated/models`.

---

## Summary

This PR regenerates Amplify models to reflect the updated backend schema and integrates the new `orderNum` field into the FAQ flow.

Changes include:

- Regenerated `AmplifyModels` with updated schema version
- Added `orderNum` to `Question` model
- Updated `Question+Schema.swift` to include the new field
- Updated `FeedingPoint` schema artifacts (auto-generated)
- Implemented deterministic FAQ sorting based on `orderNum` in `FAQModel`

All non-FAQ file changes are auto-generated artifacts produced by running:

amplify codegen models

---

## Changes

| File | What changed |
|------|--------------|
| AmplifyModels.swift | Updated schema version hash (auto-generated) |
| Question.swift | Auto-generated Added optional `orderNum: Int?` property |
| Question+Schema.swift |Auto-generated Added `.field(question.orderNum, is: .optional, ofType: .int)` |
| FeedingPoint.swift | Auto-generated schema updates |
| FeedingPoint+Schema.swift | Auto-generated schema updates |
| FAQModel.swift | Applied deterministic sorting using `orderNum` before mapping |

---

## 🧠 What happened (Root cause analysis)

During implementation of FAQ ordering:

1. Backend schema already contained `orderNum`
2. Local `schema.graphql` confirmed the field existed
3. Generated Swift models did NOT include the field
4. Root cause identified as stale generated models
5. Running `amplify codegen models` regenerated updated Swift models
6. FAQ sorting logic was then implemented safely

This clarified the Amplify generation pipeline:

AWS AppSync Schema  
↓  
Local `schema.graphql`  
↓  
Generated Swift models (`amplify/generated/models`)  

Models must be regenerated manually after schema updates.

---

## How to test
1 open Animeal Studio platform
2. add or modify question with order number
3. build the app and open FAQ page

---


<img width="250" height="470" alt="Simulator Screenshot - iPhone 15 Pro - 2026-03-04 at 00 41 31" src="https://github.com/user-attachments/assets/15ed8002-d57d-4b10-abfa-4716c33d99d0" />
<img width="981" height="407" alt="Screenshot 2026-03-04 at 00 43 25" src="https://github.com/user-attachments/assets/e6d1eb73-0cb5-4517-8b3f-8e98b5fd0ab7" />
