### PR TITLE
Bug/epmedu 4891 fix moderators inconsistency

### DIFF
--- a/animeal.xcodeproj/project.pbxproj
+++ b/animeal.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -797,6 +797,10 @@
 		FBE017622874666000A79DB2 /* Coordinatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinatable.swift; sourceTree = "<group>"; };
 		FBE4295C2874411200D1BD26 /* Common */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Common; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		C78071BC2F6F31BE008F2B5D /* ModerationDirectory */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ModerationDirectory; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		DB6B07BF28450A380009397B /* Frameworks */ = {
@@ -1647,6 +1651,7 @@
 		83C7A98228E429F900F3D219 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				C78071BC2F6F31BE008F2B5D /* ModerationDirectory */,
 				7F70590D2EE0E401000A001E /* PublicNetworkService */,
 				83D2BE8F299D66EA00AA1BC4 /* FeedingPoints */,
 				83D2BE8E299D66D500AA1BC4 /* Favorites */,
@@ -2425,6 +2430,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C78071BC2F6F31BE008F2B5D /* ModerationDirectory */,
 			);
 			name = animeal;
 			packageProductDependencies = (

--- a/animeal/src/App/AppContext.swift
+++ b/animeal/src/App/AppContext.swift
@@ -11,7 +11,8 @@ import Services
     UserProfileServiceHolder &
     DataStoreServiceHolder &
     FavoritesServiceHolder &
-    FeedingPointsServiceHolder
+    FeedingPointsServiceHolder &
+    ModerationDirectoryServiceHolder
 
 struct AppContext: AppContextProtocol {
     let analyticsService: AnalyticsServiceProtocol
@@ -23,6 +24,7 @@ struct AppContext: AppContextProtocol {
     let networkService: NetworkServiceProtocol
     let profileService: UserProfileServiceProtocol
     let dataStoreService: DataStoreServiceProtocol
+    let moderationDirectoryService: ModerationDirectoryServiceProtocol
     let favoritesService: FavoritesServiceProtocol
     let feedingPointsService: FeedingPointsServiceProtocol
     var applicationDelegateServices: [ApplicationDelegateService]
@@ -37,6 +39,7 @@ struct AppContext: AppContextProtocol {
         let networkService = NetworkService()
         let profileService = UserProfileService()
         let dataStoreService = DataStoreService()
+        let moderationDirectoryService = ModerationDirectoryService()
         let favoritesService = FavoritesService(
             networkService: networkService,
             profileService: profileService
@@ -59,6 +62,7 @@ struct AppContext: AppContextProtocol {
             networkService: networkService,
             profileService: profileService,
             dataStoreService: dataStoreService,
+            moderationDirectoryService: moderationDirectoryService,
             favoritesService: favoritesService,
             feedingPointsService: feedingPointsService,
             applicationDelegateServices: [

--- a/animeal/src/Business/Services/ModerationDirectory/ModerationDirectoryService.swift
+++ b/animeal/src/Business/Services/ModerationDirectory/ModerationDirectoryService.swift
@@ -1,0 +1,87 @@
+//
+//  ModerationDirectoryService.swift
+//  animeal
+//
+//  Created by Giorgi Amiranashvili on 22.03.26.
+//
+
+import Foundation
+import Common
+import Amplify
+
+protocol ModerationDirectoryServiceHolder {
+    var moderationDirectoryService: ModerationDirectoryServiceProtocol { get }
+}
+
+protocol ModerationDirectoryServiceProtocol: AnyObject {
+    func fetchModeratorsAndAdmins() async throws -> [ModerationDirectoryUser]
+}
+
+struct ModerationDirectoryUser: Hashable {
+    let id: String
+    let name: String
+}
+
+final class ModerationDirectoryService: ModerationDirectoryServiceProtocol {
+    private enum Constants {
+        static let apiName = "AdminQueries"
+        static let listUsersInGroupPath = "/listUsersInGroup"
+        static let moderatorGroup = "Moderator"
+        static let administratorGroup = "Administrator"
+    }
+    
+    func fetchModeratorsAndAdmins() async throws -> [ModerationDirectoryUser] {
+        async let moderators = fetchUsersInGroup(Constants.moderatorGroup)
+        async let admins = fetchUsersInGroup(Constants.administratorGroup)
+        let merged = try await moderators + admins
+        /// remove duplicates by id
+        var seen = Set<String>()
+        return merged.filter { user in
+            seen.insert(user.id).inserted
+        }
+    }
+    
+    private func fetchUsersInGroup(_ groupName: String) async throws -> [ModerationDirectoryUser] {
+        do {
+            let request = RESTRequest(
+                apiName: Constants.apiName,
+                path: Constants.listUsersInGroupPath,
+                queryParameters: ["groupname": groupName]
+            )
+            let data = try await Amplify.API.get(request: request)
+            let response = try JSONDecoder().decode(ListUsersInGroupResponse.self, from: data)
+            return response.users.map { $0.toDomain() }
+        } catch {
+            throw mapError(error)
+        }
+    }
+    
+    private func mapError(_ error: Error) -> BaseError {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return BaseError(error: nsError)
+        }
+        return L10n.Errors.somethingWrong.asBaseError(
+            failureReason: error.localizedDescription,
+            code: .unknown
+        )
+    }
+}
+
+private extension Array where Element == ModerationDirectoryUserAttributeResponse {
+    func value(for key: String) -> String? {
+        first(where: { $0.name == key })?.value
+    }
+}
+
+private extension ModerationDirectoryUserResponse {
+    func toDomain() -> ModerationDirectoryUser {
+        let firstName = userAttributes.value(for: "name") ?? ""
+        let lastName = userAttributes.value(for: "family_name") ?? ""
+        let fullName = "\(firstName) \(lastName)".trimmingCharacters(in: .whitespaces)
+        return ModerationDirectoryUser(
+            id: username,
+            name: fullName.isEmpty ? "Unknown" : fullName
+        )
+    }
+}

--- a/animeal/src/Business/Services/ModerationDirectory/model/ModerationDirectoryResponse.swift
+++ b/animeal/src/Business/Services/ModerationDirectory/model/ModerationDirectoryResponse.swift
@@ -1,0 +1,48 @@
+//
+//  AdminDirectoryResponse.swift
+//  animeal
+//
+//  Created by Giorgi Amiranashvili on 23.03.26.
+//
+
+import Foundation
+
+struct ListUsersInGroupResponse: Decodable {
+    let users: [ModerationDirectoryUserResponse]
+    
+    enum CodingKeys: String, CodingKey {
+        case users = "Users"
+    }
+}
+
+struct ModerationDirectoryUserAttributeResponse: Decodable {
+    let name: String
+    let value: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case name = "Name"
+        case value = "Value"
+    }
+}
+
+struct ModerationDirectoryUserResponse: Decodable {
+    let username: String
+    let userAttributes: [ModerationDirectoryUserAttributeResponse]
+    
+    enum CodingKeys: String, CodingKey {
+        case username = "Username"
+        case userAttributes = "UserAttributes"
+        case attributes = "Attributes"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        username = try container.decode(String.self, forKey: .username)
+        
+        if let attributes = try container.decodeIfPresent([ModerationDirectoryUserAttributeResponse].self, forKey: .userAttributes) {
+            userAttributes = attributes
+        } else {
+            userAttributes = try container.decodeIfPresent([ModerationDirectoryUserAttributeResponse].self, forKey: .attributes) ?? []
+        }
+    }
+}

--- a/animeal/src/Business/Services/Profile/UserValidationModel.swift
+++ b/animeal/src/Business/Services/Profile/UserValidationModel.swift
@@ -41,6 +41,7 @@ final class UserValidationModel: UserProfileValidationModel {
     // MARK: - Initialization
     init() {
         listenAuthChannelMessages()
+        refreshToken()
     }
 
     // MARK: - UserProfileValidationModel
@@ -70,6 +71,12 @@ final class UserValidationModel: UserProfileValidationModel {
 
     func set(userMode: UserMode?) {
         self.userMode = userMode
+    }
+    
+    func refreshToken() {
+        Task {
+            try? await Amplify.Auth.fetchAuthSession(options: .forceRefresh())
+        }
     }
 
     func reset() {
@@ -116,6 +123,9 @@ private extension UserValidationModel {
                 } else {
                     self.updateRolesFromSessionData(payload.data)
                 }
+            case HubPayload.EventName.Auth.signedIn:
+                logInfo("[App] \(#function) Auth.signedIn event occurred in AUTH channel")
+                refreshToken()
             default:
                 break
             }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
@@ -20,6 +20,7 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
 
     // MARK: - DataStore properties
     let feedingPointId: String
+    private var canModerate = false
     var feedingPointLocation: CLLocationCoordinate2D {
         guard
             let latitude = cachedFeedingPoint?.feedingPoint.location.lat,
@@ -152,6 +153,21 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
             }
         }
     }
+    
+    private func updateModerators() {
+        guard canModerate else { return }
+        moderatorsTask?.cancel()
+        
+        moderatorsTask = Task { [weak self] in
+            guard let self else { return }
+            let moderators = (try? await self.fetchAssignedModerators()) ?? []
+            
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                self.onModeratorsChange?(moderators)
+            }
+        }
+    }
 
     private func subscribeForFeedingPointChangeEvents() {
         context.feedingPointsService.feedingPoints
@@ -172,17 +188,16 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
                         } else {
                             justFavoriteMutated = false
                         }
-                        let moderators = (try? await self.fetchAssignedModerators()) ?? []
                         let mapped = self.mapper.map(
                             feedingPointModel.feedingPoint,
                             isFavorite: feedingPointModel.isFavorite,
-                            isEnabled: canBook ?? false)
-                        
+                            isEnabled: canBook ?? false
+                        )
+                        self.cachedFeedingPoint = feedingPointModel
                         await MainActor.run {
-                            self.onModeratorsChange?(moderators)
                             self.onFeedingPointChange?(mapped, justFavoriteMutated)
                         }
-                        self.cachedFeedingPoint = feedingPointModel
+                        updateModerators()
                     }
                 }
             }
@@ -197,7 +212,7 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
             .removeDuplicates()
             .sink { [weak self] canSeeModerators in
                 guard let self else { return }
-                
+                canModerate = canSeeModerators
                 moderatorsTask?.cancel()
                 moderatorsTask = nil
                 

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
@@ -12,6 +12,7 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
                         & DataStoreServiceHolder
                         & UserProfileServiceHolder
                         & FeedingPointsServiceHolder
+                        & ModerationDirectoryServiceHolder
     private let context: Context
     private var cachedFeedingPoint: FullFeedingPoint?
     private var cancellables = Set<AnyCancellable>()
@@ -108,33 +109,19 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
         let right = feedingPointDetails.count < 5 ? feedingPointDetails.count : 5
         return Array(feedingPointDetails[..<right])
     }
-    
-    private func fetchAssignedModerators() async throws -> [FeedingPointDetailsModel.Moderator] {
-        guard let fullFeedingPoint = context.feedingPointsService.storedFeedingPoints.first(where: { point in
-            point.feedingPoint.id == self.feedingPointId
-        }) else {
-            return []
-        }
-        
-        let history = try await context.feedingPointsService.fetchFeedingHistory(for: fullFeedingPoint.identifier)
-        guard !history.isEmpty else { return [] }
-        
-        let sortedByDateHistory = history.sorted { $0.updatedAt > $1.updatedAt }
 
-        let ids: [String] = sortedByDateHistory
-            .compactMap { $0.assignedModerators }
-            .flatMap { $0 }
-            .compactMap { $0 }
-        
-        let uniqueIds = Array(Set(ids))
-        guard !uniqueIds.isEmpty else { return [] }
-        
-        let namesMap = try await context.profileService.fetchUserNames(for: uniqueIds)
-        
-        let mapped = uniqueIds.map { id in
-            FeedingPointDetailsModel.Moderator(name: namesMap[id] ?? "Unknown")
-        }
-        return mapped
+    private func fetchAssignedModerators() async throws -> [FeedingPointDetailsModel.Moderator] {
+        let allModerators = try await context.moderationDirectoryService.fetchModeratorsAndAdmins()
+        let feedingPoint = try await context.networkService.query(
+            request: .get(FeedingPoint.self, byId: feedingPointId)
+        )
+        guard let relationUsers = feedingPoint?.users else { return [] }
+        try await relationUsers.fetch()
+
+        let assignedUserIds = Set(relationUsers.map(\.userId))
+        return allModerators
+            .filter { assignedUserIds.contains($0.id) }
+            .map { FeedingPointDetailsModel.Moderator(name: $0.name) }
     }
 
     func mutateFavorite() async throws -> Bool {
@@ -179,19 +166,23 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
                         .canBookFeedingPoint(for: self.feedingPointId)
                     if let feedingPointModel = updatedFeeding,
                        feedingPointModel != self.cachedFeedingPoint {
-                        var justFavoriteMutated = false
+                        let justFavoriteMutated: Bool
                         if let cached = self.cachedFeedingPoint {
                             justFavoriteMutated = feedingPointModel.onlyFavoriteMutatedOf(cached)
+                        } else {
+                            justFavoriteMutated = false
                         }
-
+                        let moderators = (try? await self.fetchAssignedModerators()) ?? []
+                        let mapped = self.mapper.map(
+                            feedingPointModel.feedingPoint,
+                            isFavorite: feedingPointModel.isFavorite,
+                            isEnabled: canBook ?? false)
+                        
+                        await MainActor.run {
+                            self.onModeratorsChange?(moderators)
+                            self.onFeedingPointChange?(mapped, justFavoriteMutated)
+                        }
                         self.cachedFeedingPoint = feedingPointModel
-                        self.onFeedingPointChange?(
-                                                   self.mapper.map(
-                                                   feedingPointModel.feedingPoint,
-                                                   isFavorite: feedingPointModel.isFavorite,
-                                                   isEnabled: canBook ?? false
-                                                   ), justFavoriteMutated
-                                                   )
                     }
                 }
             }


### PR DESCRIPTION
## Pull Request overview
**Fix assigned moderators inconsistency — align with backend relations and ensure correct role-based updates**

---

## Problem

Assigned moderators were displayed inconsistently on the Feeding Point Details screen.

- Initial state often showed incorrect or empty moderators
- Data was derived from feeding history instead of actual backend relations
- UI updates were delayed and not synchronized with user roles
- Moderators visibility logic was not properly aligned with user permissions

Root cause: the implementation relied on indirect data sources (feeding history) and lacked a proper connection to backend user-group relations.

---

## Summary

This PR introduces a dedicated Moderation Directory service and fixes moderator resolution logic to use backend relations directly.

Changes include:

- Fetch moderators and admins from backend via AdminQueries API
- Resolve assigned moderators using FeedingPoint user relations
- Remove incorrect dependency on feeding history
- Introduce role-based updates for moderators visibility
- Add token refresh to ensure up-to-date role information
- Improve async handling and UI update consistency

---

## Root Cause Analysis

### 1) Incorrect data source (Feeding history)

The previous implementation extracted moderators from:

`FeedingHistory.assignedModerators`

This approach is unreliable because:

- History may be outdated or incomplete
- Not all assigned moderators are guaranteed to appear in history
- Newly assigned moderators were not reflected immediately

Correct behavior requires using:

`FeedingPoint.users`

---

### 2) Missing backend integration for moderators

There was no dedicated mechanism to fetch:

- All moderators
- All administrators

This prevented proper filtering and mapping of assigned users.

Solution:

- Introduced `ModerationDirectoryService` to fetch users from Cognito groups:
  - `Moderator`
  - `Administrator`

---

### 3) Role synchronization issues

User roles were not always up-to-date:

- Cognito tokens were not refreshed when needed
- UI could render based on stale role data

Fix:

- Force token refresh on initialization and on `signedIn` event
- Ensure latest `cognito:groups` claims are used

---

### 4) UI update timing and async inconsistencies

Moderators were:

- Loaded too late
- Not properly cancelled/reloaded during updates
- Sometimes shown before role validation completed

Fixes:

- Introduced cancellable `moderatorsTask`
- Added `updateModerators()` with proper lifecycle handling
- Ensured updates run on `MainActor`
- Trigger updates only when user can moderate

---

## Changes

| File | What changed |
|------|--------------|
| AppContext.swift | Added `ModerationDirectoryService` to dependency container |
| ModerationDirectoryService.swift | Implemented service to fetch moderators/admins from backend |
| ModerationDirectoryResponse.swift | Added models for AdminQueries API response |
| UserValidationModel.swift | Added forced token refresh for role synchronization |
| FeedingPointDetailsModel.swift | Rewrote assigned moderators logic using FeedingPoint relations |
| FeedingPointDetailsModel.swift | Added `updateModerators()` and async task handling |

---

## 🧠 How it works (High level)

App fetches moderators/admins from Cognito via AdminQueries API  
FeedingPoint relations (`users`) provide assigned user IDs  
Service filters only assigned moderators/admins  
Names are mapped and passed to UI  

UI updates only when:
- User has permission
- Data is fully resolved

Token refresh ensures roles are always up-to-date

---

## How to test

### Assigned moderators display

1. Open Feeding Point Details screen  
2. Verify assigned moderators are displayed correctly  
3. Ensure no delay or incorrect initial state  

---

### Role-based visibility

1. Login as:
   - Moderator / Admin → moderators should be visible
   - Volunteer → moderators should NOT be visible  
   
 2. Verify role updates across sessions:
   - Sign out and sign in with a different role
   - Ensure moderators visibility updates correctly

---

### Dynamic updates

1. Assign/remove moderator from backend  
2. Trigger update (refresh or subscription)  
3. Verify UI updates correctly  

---

### Session refresh

1. Sign in with different role  
2. Ensure moderators visibility updates correctly without app restart  

---
<img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-24 at 06 23 21" src="https://github.com/user-attachments/assets/ea1ccc6d-4ea0-4d40-a0a9-272d35ac7196" />
<img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-24 at 06 24 13" src="https://github.com/user-attachments/assets/be5e4772-cb67-4b38-97ad-90b463224ad5" />
<img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-24 at 06 27 02" src="https://github.com/user-attachments/assets/1869398f-b41b-4eeb-872f-badd12426f83" />




