### PR TITLE
implement link detection in FAQ answers

### DIFF
--- a/Common/Sources/Common/Helpers/LinkDetector/DefaultLinkDetector.swift
+++ b/Common/Sources/Common/Helpers/LinkDetector/DefaultLinkDetector.swift
@@ -1,0 +1,32 @@
+//
+//  DefaultLinkDetector.swift
+//  Common
+//
+//  Created by Giorgi Amiranashvili on 23/04/2026.
+//
+
+import Foundation
+
+public final class DefaultLinkDetector: LinkDetector {
+    private let detector: NSDataDetector?
+    
+    public init() {
+        self.detector = try? NSDataDetector(
+            types: NSTextCheckingResult.CheckingType.link.rawValue
+        )
+    }
+    
+    public func detectLinks(in text: String) -> [DetectedLink] {
+        guard let detector else { return [] }
+        let range = NSRange(text.startIndex..., in: text)
+        let matches = detector.matches(in: text, range: range)
+        
+        return matches.compactMap { match -> DetectedLink? in
+            guard
+                let url = match.url,
+                let stringRange = Range(match.range, in: text)
+            else { return nil }
+            return DetectedLink(url: url, range: stringRange)
+        }
+    }
+}

--- a/Common/Sources/Common/Helpers/LinkDetector/LinkDetector.swift
+++ b/Common/Sources/Common/Helpers/LinkDetector/LinkDetector.swift
@@ -1,0 +1,24 @@
+//
+//  LinkDetector.swift
+//  Common
+//
+//  Created by Giorgi Amiranashvili on 23/04/2026.
+//
+
+import Foundation
+
+public protocol LinkDetector {
+    /// Detects URLs within the provided text.
+    /// - Returns: An array of detected links with their ranges in the original string.
+    func detectLinks(in text: String) -> [DetectedLink]
+}
+
+public struct DetectedLink: Equatable {
+    public let url: URL
+    public let range: Range<String.Index>
+
+    public init(url: URL, range: Range<String.Index>) {
+        self.url = url
+        self.range = range
+    }
+}

--- a/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/View/FAQView.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/View/FAQView.swift
@@ -111,9 +111,10 @@ extension FAQView {
                 if showAnswer {
                     VStack {
                         HStack {
-                            Text(item.answer)
+                            Text(LocalizedStringKey(item.answer))
                                 .font(designEngine.fonts.primary.regular(14)?.font)
                                 .foregroundColor(designEngine.colors.textPrimary.color)
+                                .tint(designEngine.colors.elementSpecial.color)
                             Spacer()
                         }
                         .frame(maxWidth: .infinity)

--- a/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/View/QuestionViewMapper.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/View/QuestionViewMapper.swift
@@ -9,10 +9,11 @@ protocol QuestionViewMappable {
 
 final class QuestionViewMapper: QuestionViewMappable {
     func mapQuestion(_ input: FAQModel.Question) -> FAQViewItem {
-        FAQViewItem(
+        let attributedAnswer = attributedStringWithLinks(from: input.answer.trimmingWhitespaces())
+        return FAQViewItem(
             id: input.id,
             question: input.question.trimmingWhitespaces(),
-            answer: input.answer.trimmingWhitespaces(),
+            answer: attributedAnswer,
             collapsed: true
         )
     }
@@ -21,6 +22,47 @@ final class QuestionViewMapper: QuestionViewMappable {
 struct FAQViewItem: Identifiable {
     let id: String
     let question: String
-    let answer: String
+    let answer: AttributedString
     let collapsed: Bool
+}
+
+private extension QuestionViewMapper {
+    func attributedStringWithLinks(from text: String) -> AttributedString {
+        var attributed = AttributedString(text)
+        
+        applyDetectedLinks(to: &attributed, in: text)
+        applyBareDomainLinks(to: &attributed, in: text)
+        
+        return attributed
+    }
+    
+    func applyDetectedLinks(to attributed: inout AttributedString, in text: String) {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return }
+        let matches = detector.matches(in: text, range: NSRange(text.startIndex..., in: text))
+        for match in matches {
+            guard let url = match.url,
+                  let stringRange = Range(match.range, in: text),
+                  let attributedRange = Range(stringRange, in: attributed) else { continue }
+            
+            attributed[attributedRange].link = url
+        }
+    }
+    
+    func applyBareDomainLinks(to attributed: inout AttributedString, in text: String) {
+        let pattern = #"\b(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+        
+        let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+        for match in matches {
+            guard let stringRange = Range(match.range, in: text),
+                  let attributedRange = Range(stringRange, in: attributed) else { continue }
+            
+            let matchedText = String(text[stringRange])
+            if attributed[attributedRange].link != nil {
+                continue
+            }
+            guard let url = URL(string: "https://\(matchedText)") else { continue }
+            attributed[attributedRange].link = url
+        }
+    }
 }

--- a/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/View/QuestionViewMapper.swift
+++ b/animeal/src/Flows/Main/Modules/More/Submodules/FAQ/View/QuestionViewMapper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Style
 import UIComponents
+import Common
 
 // sourcery: AutoMockable
 protocol QuestionViewMappable {
@@ -8,61 +9,41 @@ protocol QuestionViewMappable {
 }
 
 final class QuestionViewMapper: QuestionViewMappable {
+    private let linkDetector: LinkDetector
+    
+    init(linkDetector: LinkDetector = DefaultLinkDetector()) {
+        self.linkDetector = linkDetector
+    }
+    
     func mapQuestion(_ input: FAQModel.Question) -> FAQViewItem {
-        let attributedAnswer = attributedStringWithLinks(from: input.answer.trimmingWhitespaces())
+        let trimmedAnswer = input.answer.trimmingWhitespaces()
         return FAQViewItem(
             id: input.id,
             question: input.question.trimmingWhitespaces(),
-            answer: attributedAnswer,
+            answer: makeMarkdownLinkedText(from: trimmedAnswer),
             collapsed: true
         )
+    }
+    
+    /// Wraps detected URLs in markdown syntax so SwiftUI's Text(LocalizedStringKey:)
+    /// renders them as tappable links while still respecting font/color modifiers.
+    private func makeMarkdownLinkedText(from text: String) -> String {
+        let links = linkDetector.detectLinks(in: text)
+        guard !links.isEmpty else { return text }
+        
+        var result = text
+        for link in links.sorted(by: { $0.range.lowerBound > $1.range.lowerBound }) {
+            let matchedText = String(text[link.range])
+            let markdown = "[\(matchedText)](\(link.url.absoluteString))"
+            result.replaceSubrange(link.range, with: markdown)
+        }
+        return result
     }
 }
 
 struct FAQViewItem: Identifiable {
     let id: String
     let question: String
-    let answer: AttributedString
+    let answer: String
     let collapsed: Bool
-}
-
-private extension QuestionViewMapper {
-    func attributedStringWithLinks(from text: String) -> AttributedString {
-        var attributed = AttributedString(text)
-        
-        applyDetectedLinks(to: &attributed, in: text)
-        applyBareDomainLinks(to: &attributed, in: text)
-        
-        return attributed
-    }
-    
-    func applyDetectedLinks(to attributed: inout AttributedString, in text: String) {
-        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return }
-        let matches = detector.matches(in: text, range: NSRange(text.startIndex..., in: text))
-        for match in matches {
-            guard let url = match.url,
-                  let stringRange = Range(match.range, in: text),
-                  let attributedRange = Range(stringRange, in: attributed) else { continue }
-            
-            attributed[attributedRange].link = url
-        }
-    }
-    
-    func applyBareDomainLinks(to attributed: inout AttributedString, in text: String) {
-        let pattern = #"\b(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}\b"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
-        
-        let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
-        for match in matches {
-            guard let stringRange = Range(match.range, in: text),
-                  let attributedRange = Range(stringRange, in: attributed) else { continue }
-            
-            let matchedText = String(text[stringRange])
-            if attributed[attributedRange].link != nil {
-                continue
-            }
-            guard let url = URL(string: "https://\(matchedText)") else { continue }
-            attributed[attributedRange].link = url
-        }
-    }
 }


### PR DESCRIPTION
## Pull Request overview  
**Enable clickable links in FAQ answers using AttributedString**

---

## Problem

FAQ answers were displayed as plain text.

- Links were not clickable  
- Bare domains (e.g. `example.com`) were not detected  

---

## Summary

- Convert answer to `AttributedString`
- Detect URLs using `NSDataDetector`
- Detect bare domains via regex and convert to `https://` links
- Prevent duplicate link assignments

---

## Changes

| File | What changed |
|------|--------------|
| QuestionViewMapper.swift | Added link detection and AttributedString mapping |
| FAQViewItem.swift | Updated `answer` type to `AttributedString` |

---

## How to test

- Add answers with URLs and bare domains  
- Verify links are clickable  
- Ensure no duplicates or crashes  

<img width="275" height="625" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-29 at 06 33 50" src="https://github.com/user-attachments/assets/96e30116-c0ac-48e7-8f68-9b01ff4bbfbb" />
<img width="275" height="625" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-29 at 06 33 53" src="https://github.com/user-attachments/assets/4695724c-9907-4423-aa8e-6b8bd526b785" />

