### PR TITLE
Update unit-test.yml

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with: 
-          xcode-version: '26.3'
+          xcode-version: '26.4'
       - name: Build For Test
         run: |
           set -o pipefail
-          xcodebuild test -scheme animeal -project animeal.xcodeproj -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5" -parallelizeTargets -showBuildTimingSummary 2>&1 | xcbeautify --renderer github-actions
+          xcodebuild test -scheme animeal -project animeal.xcodeproj -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4" -parallelizeTargets -showBuildTimingSummary 2>&1 | xcbeautify --renderer github-actions


### PR DESCRIPTION
This pull request updates the iOS CI workflow to use the latest Xcode version and test on a newer iOS Simulator.

Environment and CI updates:

* Updated the Xcode version from `26.3` to `26.4` in the GitHub Actions workflow (`.github/workflows/unit-test.yml`).
* Changed the test destination to use the `iPhone 17` simulator with OS version `26.4` instead of `iPhone 16` with OS `18.5` (`.github/workflows/unit-test.yml`).