### PR TITLE
Fixes a family of favorites-related bugs from the second round of closed-beta feedback

### DIFF
--- a/Common/Sources/Common/AsyncValue.swift
+++ b/Common/Sources/Common/AsyncValue.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Manages async state mutations with at-most-one-in-flight guarantee.
+///
+/// Fires the first request immediately. While a request is in flight,
+/// all subsequent calls update a single pending value — coalescing them
+/// into one follow-up request once the current one completes.
+/// If the pending value matches the confirmed server state after completion,
+/// no follow-up is sent.
+@MainActor
+public final class AsyncValue<T: Equatable> {
+
+    // MARK: - Public state
+
+    public private(set) var confirmed: T
+    private var currentTarget: T?
+    private var pendingValue: T?
+
+    /// The value the UI should optimistically display.
+    /// Reflects: pending → in-flight target → confirmed.
+    public var intended: T { pendingValue ?? currentTarget ?? confirmed }
+
+    // MARK: - Callbacks
+
+    public var onConfirmed: ((T) -> Void)?
+    public var onReverted: (() -> Void)?
+
+    // MARK: - Init
+
+    public init(
+        _ initial: T,
+        onConfirmed: ((T) -> Void)? = nil,
+        onReverted: (() -> Void)? = nil
+    ) {
+        confirmed = initial
+        self.onConfirmed = onConfirmed
+        self.onReverted = onReverted
+    }
+
+    // MARK: - Public API
+
+    /// Request a mutation to `desired`. Safe to call multiple times concurrently.
+    public func mutate(to desired: T, via executor: @escaping (T) async throws -> T) {
+        guard currentTarget == nil else {
+            pendingValue = desired
+            return
+        }
+        currentTarget = desired
+        Task { @MainActor in await self.perform(desired, executor: executor) }
+    }
+
+    /// Sync the confirmed base value (e.g. from initial content load).
+    /// No-op while a mutation is in flight to avoid clobbering pending state.
+    public func update(confirmed value: T) {
+        guard currentTarget == nil else { return }
+        confirmed = value
+        pendingValue = nil
+    }
+
+    // MARK: - Private
+
+    private func perform(_ target: T, executor: @escaping (T) async throws -> T) async {
+        do {
+            let result = try await executor(target)
+            confirmed = result
+            currentTarget = nil
+            onConfirmed?(result)
+        } catch {
+            currentTarget = nil
+            onReverted?()
+        }
+
+        if let pending = pendingValue, pending != confirmed {
+            pendingValue = nil
+            currentTarget = pending
+            await perform(pending, executor: executor)
+        } else {
+            pendingValue = nil
+            currentTarget = nil
+        }
+    }
+}

--- a/Common/Sources/Common/AsyncValue.swift
+++ b/Common/Sources/Common/AsyncValue.swift
@@ -59,24 +59,28 @@ public final class AsyncValue<T: Equatable> {
 
     // MARK: - Private
 
-    private func perform(_ target: T, executor: @escaping (T) async throws -> T) async {
-        do {
-            let result = try await executor(target)
-            confirmed = result
-            currentTarget = nil
-            onConfirmed?(result)
-        } catch {
-            currentTarget = nil
-            onReverted?()
-        }
+    private func perform(_ initialTarget: T, executor: @escaping (T) async throws -> T) async {
+        var target = initialTarget
+        while true {
+            do {
+                let result = try await executor(target)
+                confirmed = result
+                currentTarget = nil
+                onConfirmed?(result)
+            } catch {
+                currentTarget = nil
+                onReverted?()
+            }
 
-        if let pending = pendingValue, pending != confirmed {
+            guard let pending = pendingValue, pending != confirmed else {
+                pendingValue = nil
+                currentTarget = nil
+                break
+            }
+
             pendingValue = nil
             currentTarget = pending
-            await perform(pending, executor: executor)
-        } else {
-            pendingValue = nil
-            currentTarget = nil
+            target = pending
         }
     }
 }

--- a/Common/Tests/CommonTests/AsyncValueTests.swift
+++ b/Common/Tests/CommonTests/AsyncValueTests.swift
@@ -1,0 +1,181 @@
+import Testing
+@testable import Common
+
+@MainActor
+@Suite("AsyncValue")
+struct AsyncValueTests {
+
+    // MARK: - Immediate dispatch
+
+    @Test("fires first request immediately without waiting")
+    func firstRequestImmediate() async throws {
+        var received: [Bool] = []
+        let sut = AsyncValue(false)
+
+        sut.mutate(to: true) { v in received.append(v); return v }
+
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(received == [true])
+        #expect(sut.confirmed == true)
+    }
+
+    // MARK: - Coalescing
+
+    @Test("concurrent taps produce at most one follow-up request")
+    func coalescesIntoOneFollowUp() async throws {
+        var received: [Bool] = []
+        let sut = AsyncValue(false)
+        let slow: (Bool) async throws -> Bool = {
+            received.append($0)
+            try await Task.sleep(for: .milliseconds(80))
+            return $0
+        }
+
+        sut.mutate(to: true, via: slow)
+        try await Task.sleep(for: .milliseconds(10))
+        sut.mutate(to: false, via: slow)
+        sut.mutate(to: true,  via: slow)
+        sut.mutate(to: false, via: slow)
+
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(received == [true, false])
+        #expect(sut.confirmed == false)
+    }
+
+    @Test("no follow-up when pending matches confirmed after first request")
+    func noFollowUpWhenPendingMatchesConfirmed() async throws {
+        var count = 0
+        let sut = AsyncValue(false)
+        let slow: (Bool) async throws -> Bool = {
+            count += 1
+            try await Task.sleep(for: .milliseconds(80))
+            return $0
+        }
+
+        sut.mutate(to: true,  via: slow)
+        try await Task.sleep(for: .milliseconds(10))
+        sut.mutate(to: false, via: slow)
+        sut.mutate(to: true,  via: slow)  // pending = true = what first request confirms
+
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(count == 1)
+        #expect(sut.confirmed == true)
+    }
+
+    // MARK: - intended
+
+    @Test("intended reflects in-flight target immediately after first tap")
+    func intendedAfterFirstTap() async throws {
+        let sut = AsyncValue(false)
+        let slow: (Bool) async throws -> Bool = {
+            try await Task.sleep(for: .milliseconds(100))
+            return $0
+        }
+
+        sut.mutate(to: true, via: slow)
+        #expect(sut.intended == true)
+    }
+
+    @Test("intended updates to pending value on subsequent taps")
+    func intendedUpdatesToPending() async throws {
+        let sut = AsyncValue(false)
+        let slow: (Bool) async throws -> Bool = {
+            try await Task.sleep(for: .milliseconds(100))
+            return $0
+        }
+
+        sut.mutate(to: true,  via: slow)
+        try await Task.sleep(for: .milliseconds(10))
+        sut.mutate(to: false, via: slow)
+        #expect(sut.intended == false)
+
+        sut.mutate(to: true, via: slow)
+        #expect(sut.intended == true)
+    }
+
+    // MARK: - Error handling
+
+    @Test("reverts confirmed state and calls onReverted on error")
+    func revertsOnError() async throws {
+        var reverted = false
+        let sut = AsyncValue(false)
+        sut.onReverted = { reverted = true }
+
+        sut.mutate(to: true) { _ in throw URLError(.networkConnectionLost) }
+
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(reverted == true)
+        #expect(sut.confirmed == false)
+    }
+
+    @Test("processes follow-up request even after first request fails")
+    func followUpAfterError() async throws {
+        var received: [Bool] = []
+        var callCount = 0
+        let sut = AsyncValue(false)
+
+        let failFirstThenSucceed: (Bool) async throws -> Bool = {
+            callCount += 1
+            received.append($0)
+            if callCount == 1 { throw URLError(.networkConnectionLost) }
+            return $0
+        }
+
+        sut.mutate(to: true, via: failFirstThenSucceed)
+        try await Task.sleep(for: .milliseconds(10))
+        sut.mutate(to: false, via: failFirstThenSucceed)
+
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(received == [true, false])
+        #expect(sut.confirmed == false)
+    }
+
+    // MARK: - update(confirmed:)
+
+    @Test("update(confirmed:) resets base state when idle")
+    func updateConfirmedWhenIdle() async throws {
+        let sut = AsyncValue(false)
+        sut.update(confirmed: true)
+        #expect(sut.confirmed == true)
+        #expect(sut.intended == true)
+    }
+
+    @Test("update(confirmed:) is ignored while mutation is in flight")
+    func updateConfirmedIgnoredDuringMutation() async throws {
+        let sut = AsyncValue(false)
+        let slow: (Bool) async throws -> Bool = {
+            try await Task.sleep(for: .milliseconds(100))
+            return $0
+        }
+
+        sut.mutate(to: true, via: slow)
+        try await Task.sleep(for: .milliseconds(10))
+        sut.update(confirmed: false)  // should be ignored
+
+        #expect(sut.confirmed == false)   // hasn't updated from executor yet
+        #expect(sut.intended == true)     // still targeting true
+
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(sut.confirmed == true)    // executor result wins
+    }
+
+    // MARK: - onConfirmed callback
+
+    @Test("onConfirmed called with server result after each completed mutation")
+    func onConfirmedCallback() async throws {
+        var confirmed: [Bool] = []
+        let sut = AsyncValue(false)
+        sut.onConfirmed = { confirmed.append($0) }
+        let slow: (Bool) async throws -> Bool = {
+            try await Task.sleep(for: .milliseconds(50))
+            return $0
+        }
+
+        sut.mutate(to: true,  via: slow)
+        try await Task.sleep(for: .milliseconds(10))
+        sut.mutate(to: false, via: slow)
+
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(confirmed == [true, false])
+    }
+}

--- a/Common/Tests/CommonTests/AsyncValueTests.swift
+++ b/Common/Tests/CommonTests/AsyncValueTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation.NSURLError
 @testable import Common
 
 @MainActor
@@ -12,7 +13,10 @@ struct AsyncValueTests {
         var received: [Bool] = []
         let sut = AsyncValue(false)
 
-        sut.mutate(to: true) { v in received.append(v); return v }
+        sut.mutate(to: true) { value in
+            received.append(value)
+            return value
+        }
 
         try await Task.sleep(for: .milliseconds(20))
         #expect(received == [true])
@@ -34,7 +38,7 @@ struct AsyncValueTests {
         sut.mutate(to: true, via: slow)
         try await Task.sleep(for: .milliseconds(10))
         sut.mutate(to: false, via: slow)
-        sut.mutate(to: true,  via: slow)
+        sut.mutate(to: true, via: slow)
         sut.mutate(to: false, via: slow)
 
         try await Task.sleep(for: .milliseconds(300))
@@ -52,10 +56,10 @@ struct AsyncValueTests {
             return $0
         }
 
-        sut.mutate(to: true,  via: slow)
+        sut.mutate(to: true, via: slow)
         try await Task.sleep(for: .milliseconds(10))
         sut.mutate(to: false, via: slow)
-        sut.mutate(to: true,  via: slow)  // pending = true = what first request confirms
+        sut.mutate(to: true, via: slow)  // pending = true = what first request confirms
 
         try await Task.sleep(for: .milliseconds(300))
         #expect(count == 1)
@@ -84,7 +88,7 @@ struct AsyncValueTests {
             return $0
         }
 
-        sut.mutate(to: true,  via: slow)
+        sut.mutate(to: true, via: slow)
         try await Task.sleep(for: .milliseconds(10))
         sut.mutate(to: false, via: slow)
         #expect(sut.intended == false)
@@ -171,7 +175,7 @@ struct AsyncValueTests {
             return $0
         }
 
-        sut.mutate(to: true,  via: slow)
+        sut.mutate(to: true, via: slow)
         try await Task.sleep(for: .milliseconds(10))
         sut.mutate(to: false, via: slow)
 

--- a/UIComponents/Sources/UIComponents/Components/Views/FeedingPointDetailsView.swift
+++ b/UIComponents/Sources/UIComponents/Components/Views/FeedingPointDetailsView.swift
@@ -40,6 +40,10 @@ public final class FeedingPointDetailsView: UIView {
         imageView.isHighlighted.toggle()
     }
 
+    public func setHighlightState(_ highlighted: Bool) {
+        imageView.isHighlighted = highlighted
+    }
+
     public func setIcon(_ icon: UIImage) {
         infoView.setIcon(icon)
     }

--- a/animeal/src/Business/Services/FeedingPoints/FeedingPointsService.swift
+++ b/animeal/src/Business/Services/FeedingPoints/FeedingPointsService.swift
@@ -71,7 +71,20 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
         static let favouritesLimit = 15
     }
 
+    private struct InnerState {
+        var innerFeedingPoints = [FullFeedingPoint]()
+        var innerFavoritePoints = [FullFeedingPoint]()
+    }
+
+    // MARK: - State
+    // Source of truth. All access goes through readState/mutateState — never touch
+    // innerState or the lock directly anywhere else in this file.
+    private let lock = NSLock()
+    private var innerState = InnerState()
+
     // MARK: - Subjects
+    // Broadcast-only mirrors of innerState — written to exclusively from mutateState,
+    // never via a direct .send() elsewhere.
     private let innerFeedingPoints = CurrentValueSubject<[FullFeedingPoint], Never>([])
     private let innerFavoritePoints = CurrentValueSubject<[FullFeedingPoint], Never>([])
     private let innerChangedFeedingPoint = PassthroughSubject<FullFeedingPoint, Never>()
@@ -93,7 +106,11 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
 
     // MARK: - Accesible properties
     var storedFeedingPoints: [FullFeedingPoint] {
-        Self.merge(viewport: innerFeedingPoints.value, favorites: innerFavoritePoints.value)
+        readState { Self.merge(viewport: $0.innerFeedingPoints, favorites: $0.innerFavoritePoints) }
+    }
+
+    var storedFavouriteFeedingPoints: [FullFeedingPoint] {
+        readState { $0.innerFavoritePoints }
     }
 
     private static func merge(viewport: [FullFeedingPoint], favorites: [FullFeedingPoint]) -> [FullFeedingPoint] {
@@ -106,10 +123,6 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
         }
         result += favorites.filter { !viewportIds.contains($0.identifier) }
         return result
-    }
-
-    var storedFavouriteFeedingPoints: [FullFeedingPoint] {
-        innerFavoritePoints.value
     }
 
     // MARK: - Dependencies
@@ -135,7 +148,7 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
 
     @discardableResult
     func fetchAll(bounds: BoundsInput) async throws -> [FullFeedingPoint] {
-        let favoriteIds = Set(innerFavoritePoints.value.map(\.identifier))
+        let favoriteIds = readState { Set($0.innerFavoritePoints.map(\.identifier)) }
 
         // getFeedingPoints returns category as a nested object — no separate fetch needed.
         let rawPoints = try await networkService.query(request: .getFeedingPoints(bounds: bounds))
@@ -148,25 +161,29 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
             )
         }
         let newIds = Set(points.map(\.identifier))
-        let kept = innerFeedingPoints.value.filter { !newIds.contains($0.identifier) }
-        innerFeedingPoints.send(points + kept)
+
+        mutateState { state in
+            let kept = state.innerFeedingPoints.filter { !newIds.contains($0.identifier) }
+            state.innerFeedingPoints = points + kept
+        }
+
         return points
     }
 
     func resetViewportPoints() {
-        innerFeedingPoints.send([])
+        mutateState { state in
+            state.innerFeedingPoints = []
+        }
     }
 
     @discardableResult
     func fetch(byIdentifier identifier: String) async throws -> FullFeedingPoint {
-        guard let index = innerFeedingPoints.value.firstIndex(
-            where: { $0.identifier == identifier }
-        )
+        guard let index = readState({ $0.innerFeedingPoints.firstIndex { $0.identifier == identifier } })
         else {
             throw "[FeedingPointsService] There is no feeding point for the provided identifier".asBaseError()
         }
 
-        let oldPoint = innerFeedingPoints.value[index]
+        let oldPoint = readState { $0.innerFeedingPoints[index] }
         guard let point = try await networkService.query(request: .get(FeedingPoint.self, byId: identifier))
             .map({ FullFeedingPoint(feedingPoint: $0, isFavorite: oldPoint.isFavorite) })
         else {
@@ -179,9 +196,7 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
     }
 
     func canBookFeedingPoint(for identifier: String) async throws -> Bool {
-        guard let point = innerFeedingPoints.value.first(
-            where: { $0.identifier == identifier }
-        )
+        guard let point = readState({ $0.innerFeedingPoints.first { $0.identifier == identifier } })
         else {
             throw ("[FeedingPointsService] Cannot fetch status because there is no feeding point for the" +
                    " provided identifier").asBaseError()
@@ -250,15 +265,20 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
             return results
         }
 
-        innerFavoritePoints.send(points)
+        // TODO: ANIMEAL-012 follow-up — this still blindly replaces innerFavoritePoints with a
+        // snapshot computed at the start of this (long, N-request) fetch. A point-patch that
+        // lands on innerState while this fetch is in flight will be overwritten here. Merge by
+        // id instead of blind replace — tracked separately, not blocking this fix.
+        mutateState { state in
+            state.innerFavoritePoints = points
+        }
+
         return points
     }
 
     @discardableResult
     func addToFavorites(byIdentifier identifier: String) async throws -> FavouriteFeedingPoint {
-        guard let point = innerFeedingPoints.value.first(
-            where: { $0.identifier == identifier }
-        )
+        guard let point = readState({ $0.innerFeedingPoints.first { $0.identifier == identifier } })
         else {
             throw ("[FeedingPointsService] Cannot add to favorites because there is no feeding point" +
                   " for the provided identifier").asBaseError()
@@ -274,9 +294,7 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
 
     @discardableResult
     func toggleFavorite(byIdentifier identifier: String) async throws -> FavouriteFeedingPoint {
-        guard let point = innerFeedingPoints.value.first(
-            where: { $0.identifier == identifier }
-        )
+        guard let point = readState({ $0.innerFeedingPoints.first { $0.identifier == identifier } })
         else {
             throw ("[FeedingPointsService] Cannot toggle because there is no feeding point for" +
                    " the provided identifier").asBaseError()
@@ -328,9 +346,7 @@ private extension FeedingPointsService {
     }
 
     func updateFeedingPoint(_ feedingPoint: FullFeedingPoint) {
-        guard let index = innerFeedingPoints.value.firstIndex(
-            where: { $0.identifier == feedingPoint.identifier }
-        )
+        guard let index = readState({ $0.innerFeedingPoints.firstIndex { $0.identifier == feedingPoint.identifier } })
         else {
             return logError("[FeedingPointsService] Feeding point cannot be updated due to absence.")
         }
@@ -339,58 +355,80 @@ private extension FeedingPointsService {
     }
 
     func updateFeedingPoint(_ favoriteFeedingPoint: FavouriteFeedingPoint) {
-        updateFavoritePoints(favoriteFeedingPoint)
-
-        guard let index = innerFeedingPoints.value.firstIndex(
-            where: { $0.identifier == favoriteFeedingPoint.identifier }
-        )
-        else {
-            return logError("[FeedingPointsService] Feeding point cannot be updated due to absence.")
-        }
-
-        var feedingPoint = innerFeedingPoints.value[index]
-        feedingPoint.isFavorite = favoriteFeedingPoint.isFavorite
-        replaceFeedingPoint(feedingPoint, at: index)
-    }
-
-    func updateFavoritePoints(_ favoriteFeedingPoint: FavouriteFeedingPoint) {
-        var favorites = innerFavoritePoints.value
-        let index = favorites.firstIndex { $0.identifier == favoriteFeedingPoint.identifier }
-
-        if favoriteFeedingPoint.isFavorite {
-            if let index {
-                favorites[index].isFavorite = true
-            } else if let point = innerFeedingPoints.value.first(
-                where: { $0.identifier == favoriteFeedingPoint.identifier }
-            ) {
-                var favoritePoint = point
-                favoritePoint.isFavorite = true
-                favorites.append(favoritePoint)
+        // Both arrays are patched inside a single mutateState call — one lock, one atomic
+        // operation — so nothing can observe favorites and viewport disagreeing mid-update.
+        let changedPoint: FullFeedingPoint? = mutateState { state in
+            let favIndex = state.innerFavoritePoints.firstIndex {
+                $0.identifier == favoriteFeedingPoint.identifier
             }
-        } else if let index {
-            favorites.remove(at: index)
+
+            if favoriteFeedingPoint.isFavorite {
+                if let favIndex {
+                    state.innerFavoritePoints[favIndex].isFavorite = true
+                } else if let point = state.innerFeedingPoints.first(where: {
+                    $0.identifier == favoriteFeedingPoint.identifier
+                }) {
+                    var favoritePoint = point
+                    favoritePoint.isFavorite = true
+                    state.innerFavoritePoints.append(favoritePoint)
+                }
+            } else if let favIndex {
+                state.innerFavoritePoints.remove(at: favIndex)
+            }
+
+            guard let viewportIndex = state.innerFeedingPoints.firstIndex(where: {
+                $0.identifier == favoriteFeedingPoint.identifier
+            }) else {
+                return nil
+            }
+            state.innerFeedingPoints[viewportIndex].isFavorite = favoriteFeedingPoint.isFavorite
+            return state.innerFeedingPoints[viewportIndex]
         }
 
-        innerFavoritePoints.send(favorites)
+        if let changedPoint {
+            innerChangedFeedingPoint.send(changedPoint)
+        }
     }
 
     func replaceFeedingPoint(_ feedingPoint: FullFeedingPoint, at index: Int) {
-        updateFeedingPoints { fedingPoints in
-            var fedingPoints = fedingPoints
+        let updatedPoint: FullFeedingPoint = mutateState { state in
             var feedingPoint = feedingPoint
-            feedingPoint.imageURL = fedingPoints[index].imageURL
-            fedingPoints.remove(at: index)
-            fedingPoints.insert(feedingPoint, at: index)
-            return fedingPoints
+            feedingPoint.imageURL = state.innerFeedingPoints[index].imageURL
+            state.innerFeedingPoints.remove(at: index)
+            state.innerFeedingPoints.insert(feedingPoint, at: index)
+            return feedingPoint
         }
 
-        innerChangedFeedingPoint.send(feedingPoint)
+        innerChangedFeedingPoint.send(updatedPoint)
     }
 
-    func updateFeedingPoints(_ modify: ([FullFeedingPoint]) -> [FullFeedingPoint]) {
-        let feedingPoints = innerFeedingPoints.value
-        let modifiedFeedingPoints = modify(feedingPoints)
-        innerFeedingPoints.send(modifiedFeedingPoints)
+    // Plain mutual exclusion — always exclusive, no reader/writer distinction. Given how
+    // rarely this is called (a handful of times per session, not a hot path), the extra
+    // throughput of a reader-writer lock isn't worth the added complexity here.
+    //
+    // Reentrancy note: nothing in this file calls readState/mutateState from inside another
+    // readState/mutateState closure — doing so would deadlock (NSLock isn't reentrant). No
+    // automatic guard is implemented; keep this invariant in mind when adding new code here.
+    private func readState<T>(_ body: (InnerState) -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(innerState)
+    }
+
+    @discardableResult
+    private func mutateState<T>(_ body: (inout InnerState) -> T) -> T {
+        lock.lock()
+        let result = body(&innerState)
+        let snapshot = innerState
+        lock.unlock()
+
+        // .send() always happens after unlock — never while the lock is held, to avoid a
+        // reentrant-call deadlock if a subscriber synchronously calls back into this service
+        // from its receiveValue.
+        innerFeedingPoints.send(snapshot.innerFeedingPoints)
+        innerFavoritePoints.send(snapshot.innerFavoritePoints)
+
+        return result
     }
 
     private func setup() {

--- a/animeal/src/Business/Services/FeedingPoints/FeedingPointsService.swift
+++ b/animeal/src/Business/Services/FeedingPoints/FeedingPointsService.swift
@@ -178,21 +178,22 @@ final class FeedingPointsService: FeedingPointsServiceProtocol {
 
     @discardableResult
     func fetch(byIdentifier identifier: String) async throws -> FullFeedingPoint {
-        guard let index = readState({ $0.innerFeedingPoints.firstIndex { $0.identifier == identifier } })
+        guard let oldPoint = readState({ $0.innerFeedingPoints.first { $0.identifier == identifier } })
         else {
             throw "[FeedingPointsService] There is no feeding point for the provided identifier".asBaseError()
         }
 
-        let oldPoint = readState { $0.innerFeedingPoints[index] }
         guard let point = try await networkService.query(request: .get(FeedingPoint.self, byId: identifier))
             .map({ FullFeedingPoint(feedingPoint: $0, isFavorite: oldPoint.isFavorite) })
         else {
             throw "[FeedingPointsService] There is no feeding point for the provided identifier".asBaseError()
         }
 
-        replaceFeedingPoint(point, at: index)
+        guard let updated = replaceFeedingPoint(point) else {
+            throw "[FeedingPointsService] Feeding point was removed while it was being updated".asBaseError()
+        }
 
-        return point
+        return updated
     }
 
     func canBookFeedingPoint(for identifier: String) async throws -> Bool {
@@ -346,12 +347,9 @@ private extension FeedingPointsService {
     }
 
     func updateFeedingPoint(_ feedingPoint: FullFeedingPoint) {
-        guard let index = readState({ $0.innerFeedingPoints.firstIndex { $0.identifier == feedingPoint.identifier } })
-        else {
-            return logError("[FeedingPointsService] Feeding point cannot be updated due to absence.")
+        if replaceFeedingPoint(feedingPoint) == nil {
+            logError("[FeedingPointsService] Feeding point cannot be updated due to absence.")
         }
-
-        replaceFeedingPoint(feedingPoint, at: index)
     }
 
     func updateFeedingPoint(_ favoriteFeedingPoint: FavouriteFeedingPoint) {
@@ -390,8 +388,14 @@ private extension FeedingPointsService {
         }
     }
 
-    func replaceFeedingPoint(_ feedingPoint: FullFeedingPoint, at index: Int) {
-        let updatedPoint: FullFeedingPoint = mutateState { state in
+    @discardableResult
+    func replaceFeedingPoint(_ feedingPoint: FullFeedingPoint) -> FullFeedingPoint? {
+        let updatedPoint: FullFeedingPoint? = mutateState { state in
+            guard let index = state.innerFeedingPoints.firstIndex(where: {
+                $0.identifier == feedingPoint.identifier
+            }) else {
+                return nil
+            }
             var feedingPoint = feedingPoint
             feedingPoint.imageURL = state.innerFeedingPoints[index].imageURL
             state.innerFeedingPoints.remove(at: index)
@@ -399,7 +403,11 @@ private extension FeedingPointsService {
             return feedingPoint
         }
 
-        innerChangedFeedingPoint.send(updatedPoint)
+        if let updatedPoint {
+            innerChangedFeedingPoint.send(updatedPoint)
+        }
+
+        return updatedPoint
     }
 
     // Plain mutual exclusion — always exclusive, no reader/writer distinction. Given how

--- a/animeal/src/Business/Services/FeedingPoints/FeedingPointsService.swift
+++ b/animeal/src/Business/Services/FeedingPoints/FeedingPointsService.swift
@@ -339,6 +339,8 @@ private extension FeedingPointsService {
     }
 
     func updateFeedingPoint(_ favoriteFeedingPoint: FavouriteFeedingPoint) {
+        updateFavoritePoints(favoriteFeedingPoint)
+
         guard let index = innerFeedingPoints.value.firstIndex(
             where: { $0.identifier == favoriteFeedingPoint.identifier }
         )
@@ -349,6 +351,27 @@ private extension FeedingPointsService {
         var feedingPoint = innerFeedingPoints.value[index]
         feedingPoint.isFavorite = favoriteFeedingPoint.isFavorite
         replaceFeedingPoint(feedingPoint, at: index)
+    }
+
+    func updateFavoritePoints(_ favoriteFeedingPoint: FavouriteFeedingPoint) {
+        var favorites = innerFavoritePoints.value
+        let index = favorites.firstIndex { $0.identifier == favoriteFeedingPoint.identifier }
+
+        if favoriteFeedingPoint.isFavorite {
+            if let index {
+                favorites[index].isFavorite = true
+            } else if let point = innerFeedingPoints.value.first(
+                where: { $0.identifier == favoriteFeedingPoint.identifier }
+            ) {
+                var favoritePoint = point
+                favoritePoint.isFavorite = true
+                favorites.append(favoritePoint)
+            }
+        } else if let index {
+            favorites.remove(at: index)
+        }
+
+        innerFavoritePoints.send(favorites)
     }
 
     func replaceFeedingPoint(_ feedingPoint: FullFeedingPoint, at index: Int) {

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesAssembler.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesAssembler.swift
@@ -12,18 +12,9 @@ final class FavouritesModuleAssembler {
     }
 
     func assemble() -> UIViewController {
-        let feedingPointsService = AppDelegate.shared.context.feedingPointsService
-
         let model = FavouritesModel()
         let viewModel = FavouritesViewModel(coordinator: coordinator, model: model)
         let view = FavouritesViewController(viewModel: viewModel)
-
-        feedingPointsService.changedFeedingPoint
-            .receive(on: DispatchQueue.main)
-            .sink { [weak viewModel] _ in
-                viewModel?.load(showLoading: false)
-            }
-            .store(in: &viewModel.cancellables)
 
         viewModel.onContentHaveBeenPrepared = { [weak view] viewState in
             view?.populateFavourites(viewState)

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesAssembler.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesAssembler.swift
@@ -22,6 +22,12 @@ final class FavouritesModuleAssembler {
         viewModel.onMediaContentHaveBeenPrepared = { [weak view] content in
             view?.applyFavouriteMediaContent(content)
         }
+        viewModel.onLoadingStateChanged = { [weak view] isLoading in
+            view?.setLoading(isLoading)
+        }
+        viewModel.onErrorIsNeededToDisplay = { [weak view] _ in
+            view?.showReloadState()
+        }
 
         return view
     }

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesContract.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesContract.swift
@@ -6,6 +6,8 @@ import Combine
 protocol FavouritesViewModelOutput: AnyObject {
     func populateFavourites(_ viewState: FavouriteViewContentState)
     func applyFavouriteMediaContent(_ content: FavouriteMediaContent)
+    func setLoading(_ isLoading: Bool)
+    func showReloadState()
 }
 
 // MARK: - Model

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesContract.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/FavouritesContract.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 // MARK: - View
 @MainActor
@@ -9,6 +10,7 @@ protocol FavouritesViewModelOutput: AnyObject {
 
 // MARK: - Model
 protocol FavouritesModelProtocol: AnyObject {
+    var favouritesDidChange: AnyPublisher<Void, Never> { get }
     func fetchFavourites(force: Bool) async throws -> [FavouritesModel.FavouriteContent]
     func fetchMediaContent(key: String, completion: ((Data?) -> Void)?)
 }

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/Model/FavouritesModel.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/Model/FavouritesModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import Services
 import Amplify
 import AWSDataStorePlugin
@@ -11,6 +12,14 @@ final class FavouritesModel: FavouritesModelProtocol {
     // MARK: - Private properties
     private let context: Context
     private let mapper: FavouriteModelMappable
+
+    // MARK: - FavouritesModelProtocol
+    var favouritesDidChange: AnyPublisher<Void, Never> {
+        context.feedingPointsService.changedFeedingPoint
+            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
 
     // MARK: - Initialization
     init(

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/View/FavouritesViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/View/FavouritesViewController.swift
@@ -10,6 +10,31 @@ final class FavouritesViewController: UIViewController {
     private let tableView = UITableView(frame: .zero, style: .grouped)
     private lazy var emptyView = EmptyView()
 
+    private enum ReloadButtonConstants {
+        static let size: CGFloat = 44.0
+    }
+
+    private lazy var reloadButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(Asset.Images.refreshIcon.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.tintColor = designEngine.colors.accent
+        button.contentHorizontalAlignment = .fill
+        button.contentVerticalAlignment = .fill
+        button.imageView?.contentMode = .scaleAspectFit
+        button.addTarget(self, action: #selector(reloadButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var reloadView: UIView = {
+        let container = UIView()
+        container.addSubview(reloadButton.prepareForAutoLayout())
+        reloadButton.centerXAnchor ~= container.centerXAnchor
+        reloadButton.centerYAnchor ~= container.centerYAnchor
+        reloadButton.widthAnchor ~= ReloadButtonConstants.size
+        reloadButton.heightAnchor ~= ReloadButtonConstants.size
+        return container
+    }()
+
     private var _favouriteItems = [FavouriteItem]()
     var favouriteItems: [FavouriteItem] {
         get {
@@ -42,6 +67,10 @@ final class FavouritesViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        viewModel.load()
+    }
+
+    @objc private func reloadButtonTapped() {
         viewModel.load()
     }
 
@@ -109,6 +138,15 @@ extension FavouritesViewController: FavouritesViewModelOutput {
         ) as? FavouriteItemCell
         else { return }
         cell.setIcon(content.favouriteIcon)
+    }
+
+    func setLoading(_ isLoading: Bool) {
+        tableView.isUserInteractionEnabled = !isLoading
+    }
+
+    func showReloadState() {
+        tableView.backgroundView = reloadView
+        favouriteItems = []
     }
 }
 

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/ViewModel/FavouritesViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/ViewModel/FavouritesViewModel.swift
@@ -15,7 +15,7 @@ final class FavouritesViewModel: FavouritesViewModelLifeCycle, FavouritesViewInt
     private let mapper: FavouriteViewItemMappable
 
     // MARK: - Cancellables
-    var cancellables = Set<AnyCancellable>()
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - State
     var onErrorIsNeededToDisplay: ((String) -> Void)?
@@ -31,6 +31,14 @@ final class FavouritesViewModel: FavouritesViewModelLifeCycle, FavouritesViewInt
         self.coordinator = coordinator
         self.mapper = mapper
         self.model = model
+        bind()
+    }
+
+    // MARK: - Binding
+    private func bind() {
+        model.favouritesDidChange
+            .sink { [weak self] in self?.load(showLoading: false) }
+            .store(in: &cancellables)
     }
 
     // MARK: - Life cycle

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/ViewModel/FavouritesViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/ViewModel/FavouritesViewModel.swift
@@ -53,9 +53,8 @@ final class FavouritesViewModel: FavouritesViewModelLifeCycle, FavouritesViewInt
         }
         updateViewItems(isBlocking: showLoading) { [weak self] in
             guard let self else { return [] }
-            let items = try await self.updateViewContentItems(force: showLoading)
-            self.shimmerScheduler.stop()
-            return items
+            defer { self.shimmerScheduler.stop() }
+            return try await self.updateViewContentItems(force: showLoading)
         }
     }
 

--- a/animeal/src/Flows/Main/Modules/Favourites/Favourites/ViewModel/FavouritesViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Favourites/Favourites/ViewModel/FavouritesViewModel.swift
@@ -21,6 +21,7 @@ final class FavouritesViewModel: FavouritesViewModelLifeCycle, FavouritesViewInt
     var onErrorIsNeededToDisplay: ((String) -> Void)?
     var onContentHaveBeenPrepared: ((FavouriteViewContentState) -> Void)?
     var onMediaContentHaveBeenPrepared: ((FavouriteMediaContent) -> Void)?
+    var onLoadingStateChanged: ((Bool) -> Void)?
 
     // MARK: - Initialization
     init(
@@ -44,15 +45,17 @@ final class FavouritesViewModel: FavouritesViewModelLifeCycle, FavouritesViewInt
     // MARK: - Life cycle
     func load(showLoading: Bool) {
         if showLoading {
+            onLoadingStateChanged?(true)
             shimmerScheduler.start()
             updateViewItems { [weak self] in
                 self?.updateViewLoadingItems() ?? []
             }
         }
-        updateViewItems { [weak self] in
+        updateViewItems(isBlocking: showLoading) { [weak self] in
             guard let self else { return [] }
+            let items = try await self.updateViewContentItems(force: showLoading)
             self.shimmerScheduler.stop()
-            return try await self.updateViewContentItems(force: showLoading)
+            return items
         }
     }
 
@@ -83,9 +86,18 @@ final class FavouritesViewModel: FavouritesViewModelLifeCycle, FavouritesViewInt
     }
 
     private func updateViewItems(
+        isBlocking: Bool = false,
         _ operation: @escaping () async throws -> [FavouriteItem]
     ) {
         Task { [weak self] in
+            defer {
+                if isBlocking {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onLoadingStateChanged?(false)
+                    }
+                }
+            }
+
             do {
                 let viewItems = try await operation()
 

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
@@ -49,7 +49,7 @@ protocol FeedingPointDetailsModelProtocol: AnyObject {
     func fetchFeedingPoint(_ completion: ((FeedingPointDetailsModel.PointContent) -> Void)?)
     func fetchFeedingHistory(_ completion: (([FeedingPointDetailsModel.Feeder]) -> Void)?)
     func fetchMediaContent(key: String, completion: ((Data?) -> Void)?)
-    func mutateFavorite() async throws -> Bool
+    func setFavorite(_ isFavorite: Bool) async throws
 }
 
 // sourcery: AutoMockable

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsContract.swift
@@ -32,7 +32,7 @@ protocol FeedingPointDetailsViewState: AnyObject {
     var onMediaContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointMediaContent) -> Void)? { get set }
     var onModeratorsHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointModerators) -> Void)? { get set }
     var onFavoriteMutationFailed: (() -> Void)? { get set }
-    var onFavoriteMutation: (() -> Void)? { get set }
+    var onFavoriteMutation: ((Bool) -> Void)? { get set }
     var showOnMapAction: ButtonView.Model? { get }
     var shimmerScheduler: ShimmerViewScheduler { get }
     var historyInitialized: Bool { get }

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreLocation
+import Common
 import UIComponents
 import Services
 
@@ -26,6 +27,7 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
     // TODO: Move this strange logic to model
     let isOverMap: Bool
     private var shouldShowOnMap = true
+    private let favoriteState: AsyncValue<Bool>
     var showOnMapAction: ButtonView.Model? {
         if isOverMap { return .none }
 
@@ -55,6 +57,9 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
         self.contentMapper = contentMapper
         self.coordinator = coordinator
         self.locationService = locationService
+        self.favoriteState = AsyncValue<Bool>(false)
+        favoriteState.onConfirmed = { [weak self] isFavorite in self?.onFavoriteMutation?(isFavorite) }
+        favoriteState.onReverted = { [weak self] in self?.onFavoriteMutationFailed?() }
         setup()
     }
 
@@ -81,11 +86,8 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
         }
         model.onFeedingPointChange = { [weak self] content, mutateFavorites in
             DispatchQueue.main.async {
-                if mutateFavorites {
-                    self?.updateFavorites(isFavorite: content.isFavorite)
-                } else {
-                    self?.updateContent(content)
-                }
+                guard !mutateFavorites else { return }
+                self?.updateContent(content)
             }
         }
     }
@@ -102,6 +104,7 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
     }
 
     private func updateContent(_ modelContent: FeedingPointDetailsModel.PointContent) {
+        favoriteState.update(confirmed: modelContent.content.isFavorite)
         shouldShowOnMap = modelContent.action.isEnabled
         loadMediaContent(modelContent.content.header.cover)
         onContentHaveBeenPrepared?(contentMapper.mapFeedingPoint(modelContent))
@@ -141,10 +144,6 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
         self.allModerators = moderators
     }
 
-    private func updateFavorites(isFavorite: Bool) {
-        onFavoriteMutation?(isFavorite)
-    }
-
     private func updateFeedingHistoryContent(_ modelContent: [FeedingPointDetailsModel.Feeder]) {
         let mappedContent = contentMapper.mapFeedingHistory(modelContent)
         onFeedingHistoryHaveBeenPrepared?(mappedContent)
@@ -173,16 +172,9 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
             }
 
         case .tapFavorite:
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                do {
-                    let success = try await model.mutateFavorite()
-                    if !success {
-                        self.onFavoriteMutationFailed?()
-                    }
-                } catch {
-                    self.onFavoriteMutationFailed?()
-                }
+            favoriteState.mutate(to: !favoriteState.intended) { [weak self] desired in
+                try await self?.model.setFavorite(desired)
+                return desired
             }
 
         case .tapShowOnMap:

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/FeedingPointDetailsViewModel.swift
@@ -18,7 +18,7 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
     var onMediaContentHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointMediaContent) -> Void)?
     var onModeratorsHaveBeenPrepared: ((FeedingPointDetailsViewMapper.FeedingPointModerators) -> Void)?
     var onFavoriteMutationFailed: (() -> Void)?
-    var onFavoriteMutation: (() -> Void)?
+    var onFavoriteMutation: ((Bool) -> Void)?
     var onRequestLocationAccess: (() -> Void)?
     var historyInitialized = false
     var moderatorsInitialized = false
@@ -82,7 +82,7 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
         model.onFeedingPointChange = { [weak self] content, mutateFavorites in
             DispatchQueue.main.async {
                 if mutateFavorites {
-                    self?.updateFavorites()
+                    self?.updateFavorites(isFavorite: content.isFavorite)
                 } else {
                     self?.updateContent(content)
                 }
@@ -141,8 +141,8 @@ final class FeedingPointDetailsViewModel: FeedingPointDetailsViewModelLifeCycle,
         self.allModerators = moderators
     }
 
-    private func updateFavorites() {
-        onFavoriteMutation?()
+    private func updateFavorites(isFavorite: Bool) {
+        onFavoriteMutation?(isFavorite)
     }
 
     private func updateFeedingHistoryContent(_ modelContent: [FeedingPointDetailsModel.Feeder]) {

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/Model/FeedingPointDetailsModel.swift
@@ -125,16 +125,12 @@ final class FeedingPointDetailsModel: FeedingPointDetailsModelProtocol, FeedingP
             .map { FeedingPointDetailsModel.Moderator(name: $0.name) }
     }
 
-    func mutateFavorite() async throws -> Bool {
-        guard let feedingPoint = cachedFeedingPoint else {
-            return false
-        }
-        if feedingPoint.isFavorite {
-            try await context.feedingPointsService.deleteFromFavorites(byIdentifier: feedingPointId)
-        } else {
+    func setFavorite(_ isFavorite: Bool) async throws {
+        if isFavorite {
             try await context.feedingPointsService.addToFavorites(byIdentifier: feedingPointId)
+        } else {
+            try await context.feedingPointsService.deleteFromFavorites(byIdentifier: feedingPointId)
         }
-        return true
     }
 
     func fetchMediaContent(key: String, completion: ((Data?) -> Void)?) {

--- a/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
+++ b/animeal/src/Flows/Main/Modules/Home/FeedingPointDetails/View/FeedingPointDetailsViewController.swift
@@ -75,8 +75,8 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
             self?.applyFavoriteMutationFailed()
         }
 
-        viewModel.onFavoriteMutation = { [weak self] in
-            self?.applyFavoriteMutation()
+        viewModel.onFavoriteMutation = { [weak self] isFavorite in
+            self?.applyFavoriteMutation(isFavorite: isFavorite)
         }
 
         viewModel.onRequestLocationAccess = { [weak self] in
@@ -199,10 +199,8 @@ final class FeedingPointDetailsViewController: UIViewController, FeedingPointDet
         pointDetailsView.toggleHighlightState()
     }
 
-    func applyFavoriteMutation() {
-        pointDetailsView.didTapOnFavorite = { [weak self] in
-            self?.viewModel.handleActionEvent(.tapFavorite)
-        }
+    func applyFavoriteMutation(isFavorite: Bool) {
+        pointDetailsView.setHighlightState(isFavorite)
     }
 
     func applyFeedingPointContent(

--- a/animealTests/Sourcery/Generated/AutoMockable.generated.swift
+++ b/animealTests/Sourcery/Generated/AutoMockable.generated.swift
@@ -581,26 +581,25 @@ class FeedingPointDetailsModelProtocolMock: FeedingPointDetailsModelProtocol {
         fetchMediaContentKeyCompletionClosure?(key, completion)
     }
 
-    // MARK: - mutateFavorite
+    // MARK: - setFavorite
 
-    var mutateFavoriteThrowableError: Error?
-    var mutateFavoriteCallsCount = 0
-    var mutateFavoriteCalled: Bool {
-        return mutateFavoriteCallsCount > 0
+    var setFavoriteThrowableError: Error?
+    var setFavoriteCallsCount = 0
+    var setFavoriteCalled: Bool {
+        return setFavoriteCallsCount > 0
     }
-    var mutateFavoriteReturnValue: Bool!
-    var mutateFavoriteClosure: (() async throws -> Bool)?
+    var setFavoriteReceivedIsFavorite: Bool?
+    var setFavoriteReceivedInvocations: [Bool] = []
+    var setFavoriteClosure: ((Bool) async throws -> Void)?
 
-    func mutateFavorite() async throws -> Bool {
-        if let error = mutateFavoriteThrowableError {
+    func setFavorite(_ isFavorite: Bool) async throws {
+        if let error = setFavoriteThrowableError {
             throw error
         }
-        mutateFavoriteCallsCount += 1
-        if let mutateFavoriteClosure = mutateFavoriteClosure {
-            return try await mutateFavoriteClosure()
-        } else {
-            return mutateFavoriteReturnValue
-        }
+        setFavoriteCallsCount += 1
+        setFavoriteReceivedIsFavorite = isFavorite
+        setFavoriteReceivedInvocations.append(isFavorite)
+        try await setFavoriteClosure?(isFavorite)
     }
 
 }


### PR DESCRIPTION
- Heart icon on the feeding point details screen no longer gets stuck out of sync with the confirmed server state after tapping (introduces `AsyncValue<T>` — at-most-one-in-flight optimistic mutation with confirm/revert).
- Favourites list and reopened details cards no longer show a stale favorite state — `FeedingPointsService`'s favorites cache is now patched in place on add/remove instead of only being refreshed by a full re-fetch.
- Closed a real race condition in `FeedingPointsService`: a long-running `fetchAllFavorites()` could blindly overwrite a more recent point-level patch. State is now serialized behind a single lock (`readState`/`mutateState`).
- Favourites screen blocks navigation to Details while a refresh is in flight (closes most of the remaining race window) and shows a reload button instead of a stuck/empty screen if the refresh fails.
- Fixed a pre-existing bug where the loading shimmer was stopped before the fetch it was covering had actually finished.