### PR TITLE
Bump version to 1.0.1; add bump_version.sh and animeal-version skill

### DIFF
--- a/.claude/skills/animeal-version/SKILL.md
+++ b/.claude/skills/animeal-version/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: animeal-version
+description: Bump the app marketing version (MARKETING_VERSION) for animeal_iOS via Tools/bump_version.sh — patch (default), minor, major (requires user confirmation), or an explicit X.Y.Z. Commits the bump on a dedicated branch. Build number is managed separately by Tools/update_build_number.sh.
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+triggers:
+  - bump version
+  - bump the version
+  - new app version
+  - animeal version
+---
+
+# animeal-version — bump the app marketing version
+
+All logic lives in `Tools/bump_version.sh` — this skill only translates intent and handles confirmation.
+
+1. Map the user's request to an argument: `patch` (default when unspecified), `minor`, `major`, or an explicit `X.Y.Z`.
+2. If the bump changes the **first** number (major, or an explicit version with a different major), ask the user first via AskUserQuestion (**Yes, bump major** / **Cancel**). On Cancel, stop.
+3. Run:
+   ```bash
+   bash Tools/bump_version.sh <arg>          # confirmed major: add --yes
+   ```
+   The script validates everything itself (consistency across configurations, exact replacement count) and fails loudly — report its errors to the user verbatim, do not work around them.
+4. Commit `animeal.xcodeproj/project.pbxproj` on a branch `feature/bump_version_<X_Y_Z>` (create it off up-to-date `develop` if not already on a dedicated branch) with message `Bump version to <X.Y.Z>`. Do not push unless asked.

--- a/Tools/bump_version.sh
+++ b/Tools/bump_version.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+#
+# Bump Marketing Version Script
+#
+# Bumps MARKETING_VERSION (semver MAJOR.MINOR.PATCH) for the main app target
+# in animeal.xcodeproj/project.pbxproj.
+#
+# Only the main app target is touched: its three build configurations
+# (Test/Debug/Release) hold the version in full X.Y.Z form. Test/UI-test/demo
+# targets use the two-part form "1.0" and are never modified.
+#
+# CURRENT_PROJECT_VERSION (build number) is out of scope — it is managed by
+# Tools/update_build_number.sh.
+#
+# USAGE:
+#   bash Tools/bump_version.sh              # patch bump (default): 1.0.0 -> 1.0.1
+#   bash Tools/bump_version.sh patch
+#   bash Tools/bump_version.sh minor        # 1.0.1 -> 1.1.0
+#   bash Tools/bump_version.sh major        # 1.1.0 -> 2.0.0 (requires confirmation)
+#   bash Tools/bump_version.sh 1.2.3        # set explicit version
+#   bash Tools/bump_version.sh major --yes  # skip interactive major confirmation
+#
+# A major bump (first number changes) must be confirmed: interactively when
+# run in a terminal, or with --yes otherwise.
+
+set -euo pipefail
+
+PROJECT_FILE="$(dirname "$0")/../animeal.xcodeproj/project.pbxproj"
+
+if [ ! -f "$PROJECT_FILE" ]; then
+    echo "❌ Project file not found: $PROJECT_FILE"
+    exit 1
+fi
+
+MODE="${1:-patch}"
+CONFIRM_FLAG="${2:-}"
+
+# --- Read current version (main target entries are in full X.Y.Z form) ---
+CURRENT_VERSIONS=$(grep -oE 'MARKETING_VERSION = [0-9]+\.[0-9]+\.[0-9]+;' "$PROJECT_FILE" | sort -u)
+COUNT_UNIQUE=$(echo "$CURRENT_VERSIONS" | grep -c . || true)
+
+if [ "$COUNT_UNIQUE" -eq 0 ]; then
+    echo "❌ No X.Y.Z MARKETING_VERSION entries found in $PROJECT_FILE"
+    exit 1
+fi
+if [ "$COUNT_UNIQUE" -gt 1 ]; then
+    echo "❌ Main-target MARKETING_VERSION values diverged — fix manually first:"
+    echo "$CURRENT_VERSIONS"
+    exit 1
+fi
+
+CURRENT=$(echo "$CURRENT_VERSIONS" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+ENTRY_COUNT=$(grep -c "MARKETING_VERSION = $CURRENT;" "$PROJECT_FILE")
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+# --- Compute new version ---
+case "$MODE" in
+    patch) NEW="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+    minor) NEW="$MAJOR.$((MINOR + 1)).0" ;;
+    major) NEW="$((MAJOR + 1)).0.0" ;;
+    *)
+        if [[ "$MODE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            NEW="$MODE"
+        else
+            echo "❌ Invalid argument: '$MODE' (expected patch | minor | major | X.Y.Z)"
+            exit 1
+        fi
+        ;;
+esac
+
+if [ "$NEW" = "$CURRENT" ]; then
+    echo "ℹ️ Version is already $CURRENT — nothing to do"
+    exit 0
+fi
+
+# --- Major bump gate ---
+NEW_MAJOR="${NEW%%.*}"
+if [ "$NEW_MAJOR" != "$MAJOR" ]; then
+    if [ "$CONFIRM_FLAG" = "--yes" ]; then
+        :
+    elif [ -t 0 ]; then
+        read -r -p "⚠️ MAJOR bump: $CURRENT -> $NEW. Type 'yes' to confirm: " ANSWER
+        if [ "$ANSWER" != "yes" ]; then
+            echo "Cancelled"
+            exit 1
+        fi
+    else
+        echo "❌ MAJOR bump ($CURRENT -> $NEW) requires confirmation: re-run with --yes"
+        exit 1
+    fi
+fi
+
+# --- Apply ---
+sed -i '' "s/MARKETING_VERSION = $CURRENT;/MARKETING_VERSION = $NEW;/g" "$PROJECT_FILE"
+
+NEW_COUNT=$(grep -c "MARKETING_VERSION = $NEW;" "$PROJECT_FILE")
+if [ "$NEW_COUNT" -ne "$ENTRY_COUNT" ]; then
+    echo "❌ Expected $ENTRY_COUNT replacements, found $NEW_COUNT — reverting"
+    sed -i '' "s/MARKETING_VERSION = $NEW;/MARKETING_VERSION = $CURRENT;/g" "$PROJECT_FILE"
+    exit 1
+fi
+
+echo "✅ MARKETING_VERSION: $CURRENT -> $NEW ($NEW_COUNT configurations)"

--- a/animeal.xcodeproj/project.pbxproj
+++ b/animeal.xcodeproj/project.pbxproj
@@ -943,7 +943,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1101,7 +1101,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1138,7 +1138,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## What

- Bump `MARKETING_VERSION` 1.0.0 → 1.0.1 for the main app target (Test/Debug/Release configurations). Test/UI-test/demo targets (`1.0`) are untouched.
- Add `Tools/bump_version.sh` — semver bump script (`patch` | `minor` | `major` | explicit `X.Y.Z`). Validates that all main-target configurations hold the same version, verifies the exact replacement count (reverts on mismatch), and gates major bumps behind an interactive confirmation or `--yes` flag. Sits next to `Tools/update_build_number.sh`, which keeps owning the build number.
- Add `.claude/skills/animeal-version` — a thin Claude Code skill that translates intent into a script argument, asks for confirmation on major bumps, and commits the bump on a dedicated branch.

## Why

Version bump for the next TestFlight release, plus tooling so future bumps are a one-liner instead of a manual `project.pbxproj` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)