### PR TITLE
Fix IPA build: restore Configurations as a plain group for xcodeproj compat

### DIFF
--- a/animeal.xcodeproj/project.pbxproj
+++ b/animeal.xcodeproj/project.pbxproj
@@ -189,10 +189,10 @@
 		FB4313512848E3850084C21A /* Style */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Style; sourceTree = "<group>"; };
 		FB4313562848E97C0084C21A /* animealUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = animealUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBE4295C2874411200D1BD26 /* Common */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Common; sourceTree = "<group>"; };
-		20939F4A34A643E3BF8FFD44 /* Dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Dev.xcconfig; path = animeal/Configurations/Dev.xcconfig; sourceTree = "<group>"; };
-		2B2D0E8FFA2648BCBFB376D1 /* Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Test.xcconfig; path = animeal/Configurations/Test.xcconfig; sourceTree = "<group>"; };
-		82220ED3F517460590DEE105 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = animeal/Configurations/Shared.xcconfig; sourceTree = "<group>"; };
-		9B17BEDCB9DD49F5AE4E2AEB /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = animeal/Configurations/Release.xcconfig; sourceTree = "<group>"; };
+		20939F4A34A643E3BF8FFD44 /* Dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Dev.xcconfig; sourceTree = "<group>"; };
+		2B2D0E8FFA2648BCBFB376D1 /* Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Test.xcconfig; sourceTree = "<group>"; };
+		82220ED3F517460590DEE105 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
+		9B17BEDCB9DD49F5AE4E2AEB /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -213,7 +213,6 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		C1EE9512300CEFAB002BFF95 /* Configurations */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Configurations; sourceTree = "<group>"; };
 		C1EE9A41300CF023002BFF95 /* src */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = src; sourceTree = "<group>"; };
 		C1EE9A4A300CF055002BFF95 /* Sourcery */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C1EE9A4F300CF056002BFF95 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sourcery; sourceTree = "<group>"; };
 		C1EE9A5D300CF061002BFF95 /* animealUI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C1EE9A66300CF062002BFF95 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = animealUI; sourceTree = "<group>"; };
@@ -308,6 +307,17 @@
 				FB4313562848E97C0084C21A /* animealUI.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		C1EE9512300CEFAB002BFF95 /* Configurations */ = {
+			isa = PBXGroup;
+			children = (
+				82220ED3F517460590DEE105 /* Shared.xcconfig */,
+				20939F4A34A643E3BF8FFD44 /* Dev.xcconfig */,
+				2B2D0E8FFA2648BCBFB376D1 /* Test.xcconfig */,
+				9B17BEDCB9DD49F5AE4E2AEB /* Release.xcconfig */,
+			);
+			path = Configurations;
 			sourceTree = "<group>";
 		};
 		DB6B07C428450A380009397B /* animeal */ = {


### PR DESCRIPTION
## What

Reverts the `Configurations` folder from an Xcode 16 `PBXFileSystemSynchronizedRootGroup` back to a classic `PBXGroup` holding the four xcconfig file references (with group-relative paths), exactly as it was before #301.

## Why

The Generate IPA run for the 1.0.1 bump failed before compiling anything:

```
[Xcodeproj] Consistency issue: no parent for object `Release.xcconfig`: `Release`, `Release` (RuntimeError)
```

#301 converted `Configurations` to a synchronized folder, which left the xcconfig `PBXFileReference` entries (still needed for `baseConfigurationReference`) without a parent group. Xcode handles this fine, but the `xcodeproj` gem used by fastlane inside `yukiarrr/ios-build-action` does not.

Verified locally: `Xcodeproj::Project.open` + resolving `base_configuration_reference.real_path` for every target/configuration now succeeds (this is the exact operation that crashed), and the project still parses and lists schemes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)