### PR TITLE
EPMEDU-4983: Fix feeding flow crash; set up Crashlytics

### DIFF
--- a/Services/Package.swift
+++ b/Services/Package.swift
@@ -28,9 +28,6 @@ let package = Package(
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                 .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk")
-            ],
-            swiftSettings: [
-                .define("FIREBASE_DISABLED")
             ]),
         .testTarget(
             name: "ServicesTests",

--- a/animeal.xcodeproj/project.pbxproj
+++ b/animeal.xcodeproj/project.pbxproj
@@ -953,7 +953,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,7 +999,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1111,7 +1111,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1148,7 +1148,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/animeal/Configurations/Shared.xcconfig
+++ b/animeal/Configurations/Shared.xcconfig
@@ -4,6 +4,8 @@ INFOPLIST_KEY_CFBundleDisplayName = AnimealDemo
 
 // ─── Feature flags ───────────────────────────────────────────────────────────
 // Default value of FeatureFlags.isLoadAllFeedingPointsEnabled for this build configuration.
-SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) LOAD_ALL_FEEDING_POINTS FIREBASE_DISABLED
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) LOAD_ALL_FEEDING_POINTS
 
-FIREBASE_DISABLED = YES
+// Script-only toggle: gates the Crashlytics dSYM-upload build phase.
+// Swift-code gating (#if FIREBASE_DISABLED) lives in Services/Package.swift swiftSettings.
+FIREBASE_DISABLED = NO

--- a/animeal/res/GoogleService-Info.plist
+++ b/animeal/res/GoogleService-Info.plist
@@ -2,20 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ANDROID_CLIENT_ID</key>
-	<string>397207162579-71cjc37lm6kq3584p0dgq3tr4tdroql9.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
-	<string>AIzaSyDluqN6jg9CdqL9fEFI42TjWXm1lm3JiD4</string>
+	<string>AIzaSyCnOCrUhdT9fUzbtyCs0ExGQ9qLmdXiHWE</string>
 	<key>GCM_SENDER_ID</key>
-	<string>397207162579</string>
+	<string>226206918500</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.epmedu.animealMobile</string>
+	<string>com.serhiiterokhyn.animeal.demo</string>
 	<key>PROJECT_ID</key>
-	<string>animeal-project</string>
+	<string>animeal-demo</string>
 	<key>STORAGE_BUCKET</key>
-	<string>animeal-project.appspot.com</string>
+	<string>animeal-demo.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -27,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:397207162579:ios:326b7ff58418b548774e26</string>
+	<string>1:226206918500:ios:e3db0c1391e43d78d03c71</string>
 </dict>
 </plist>

--- a/animeal/src/Flows/Main/Modules/Home/Main/HomeViewModel.swift
+++ b/animeal/src/Flows/Main/Modules/Home/Main/HomeViewModel.swift
@@ -93,7 +93,7 @@ final class HomeViewModel: HomeViewModelLifeCycle, HomeViewInteraction, HomeView
     }
 
     func load() {
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
             await fetchUnfinishedFeeding()
             self.fetchFilterItems()
@@ -112,7 +112,7 @@ final class HomeViewModel: HomeViewModelLifeCycle, HomeViewInteraction, HomeView
         guard !(loadedRegion?.contains(bounds) ?? false), !isFetchingFeedingPoints else { return }
         let fetchBounds = makeFetchBounds(from: bounds)
         isFetchingFeedingPoints = true
-        pendingFetchTask = Task { [weak self] in
+        pendingFetchTask = Task { @MainActor [weak self] in
             guard let self else { return }
             defer { self.isFetchingFeedingPoints = false }
             do {


### PR DESCRIPTION
## Feeding flow crash (EPMEDU-4983)

The camera-idle fetch task and the load() task ran off the main thread, so map
callbacks hit UIKit/Mapbox main-thread-only APIs from a background executor —
crashing during an active feeding (route showcased, then category switched).
Both tasks are now pinned to @MainActor, which also serializes the fetch-state
flags with the main-actor refresh path.

## Crashlytics

- New Firebase project (animeal-demo, personal account) matching the current
  bundle id; replaced the stale GoogleService-Info.plist
- Removed the FIREBASE_DISABLED gate (xcconfig + Services package)
- Debug builds now produce a dSYM so the crashlytics build phase uploads
  symbols automatically
- Verified end-to-end: forced a crash in the simulator, the symbolicated
  report showed up in the Firebase console

## Misc

- Version bumped to 1.0.2